### PR TITLE
CLEANUP: Add warnings, add const to char *

### DIFF
--- a/Makefile.unx
+++ b/Makefile.unx
@@ -29,7 +29,11 @@ LIBS = $(ZLIB)
 CC = gcc
 LD = gcc
 RM = rm
-CFLAGS = -O -Wall $(INCS) -DUSE_ZLIB
+CERRORS=-Werror -Wall -Wextra -Wundef -Wpointer-arith\
+	-Wmissing-declarations -Wstrict-prototypes -Wmissing-prototypes\
+	-Wno-implicit-fallthrough -Wwrite-strings
+
+CFLAGS = -O ${CERRORS} $(INCS) -DUSE_ZLIB
 # [note that -Wall is a gcc-specific compilation flag ("all warnings on")]
 O = .o
 E =

--- a/pngcheck.c
+++ b/pngcheck.c
@@ -182,30 +182,32 @@ typedef struct printbuf_state {
   int esc;
 } printbuf_state;
 
-/* int  main (int argc, char *argv[]); */
+/* int  main (int argc, const char *argv[]); */
 void usage (FILE *fpMsg);
 #ifndef USE_ZLIB
 void make_crc_table (void);
 ulg  update_crc (ulg crc, uch *buf, int len);
 #endif
-ulg  getlong (FILE *fp, char *fname, char *where);
+ulg  getlong (FILE *fp, const char *fname, const char *where);
 void putlong (FILE *fpOut, ulg ul);
 void init_printbuf_state (printbuf_state *prbuf);
 void print_buffer (printbuf_state *prbuf, uch *buffer, int size, int indent);
-void report_printbuf (printbuf_state *prbuf, char *fname, char *chunkid);
+void report_printbuf (printbuf_state *prbuf, const char *fname, char *chunkid);
 int  keywordlen (uch *buffer, int maxsize);
 const char *getmonth (int m);
 int  ratio (ulg uc, ulg c);
 ulg  gcf (ulg a, ulg b);
-int  pngcheck (FILE *fp, char *_fname, int searching, FILE *fpOut);
-int  pnginfile (FILE *fp, char *fname, int ipng, int extracting);
-void pngsearch (FILE *fp, char *fname, int extracting);
-int  check_magic (uch *magic, char *fname, int which);
-int  check_chunk_name (char *chunk_name, char *fname);
+int  pngcheck (FILE *fp, const char *_fname, int searching, FILE *fpOut);
+int  pnginfile (FILE *fp, const char *fname, int ipng, int extracting);
+void pngsearch (FILE *fp, const char *fname, int extracting);
+int  check_magic (uch *magic, const char *fname, int which);
+int  check_chunk_name (const char *chunk_name, const char *fname);
 int  check_keyword (uch *buffer, int maxsize, int *pKeylen,
-                    char *keyword_name, char *chunkid, char *fname);
-int  check_text (uch *buffer, int maxsize, char *chunkid, char *fname);
-int  check_ascii_float (uch *buffer, int len, char *chunkid, char *fname);
+        const char *keyword_name, const char *chunkid, const char *fname);
+int  check_text (uch *buffer, int maxsize, const char *chunkid,
+        const char *fname);
+int  check_ascii_float (uch *buffer, int len, const char *chunkid,
+        const char *fname);
 char const * u2name_helper(unsigned int value, const char **names,
                            size_t nnames);
 
@@ -562,7 +564,7 @@ const char *no_err_plain = "No errors detected";
 
 
 
-int main(int argc, char *argv[])
+int main(int argc, const char *argv[])
 {
   FILE *fp;
   int i = 1;
@@ -653,7 +655,7 @@ int main(int argc, char *argv[])
     if (isatty(0)) { /* if stdin not redirected, give the user help */
       usage(stdout);
     } else {
-      char *fname = "stdin";
+      const char *fname = "stdin";
 
       if (search)
         pngsearch(stdin, fname, extract);  /* currently returns void */
@@ -688,7 +690,7 @@ int main(int argc, char *argv[])
 
     /* main loop over files listed on command line */
     for (i = 1; i < argc; ++i) {
-      char *fname = argv[i];
+      const char *fname = argv[i];
 
       err = kOK;
       if (strcmp(fname, "-") == 0) {
@@ -840,7 +842,7 @@ ulg update_crc(ulg crc, uch *buf, int len)
 
 
 
-ulg getlong(FILE *fp, char *fname, char *where)
+ulg getlong(FILE *fp, const char *fname, const char *where)
 {
   ulg res = 0;
   int j;
@@ -929,7 +931,7 @@ void print_buffer(printbuf_state *prbuf, uch *buf, int size, int indent)
 
 
 
-void report_printbuf(printbuf_state *prbuf, char *fname, char *chunkid)
+void report_printbuf(printbuf_state *prbuf, const char *fname, char *chunkid)
 {
   if (prbuf->cr) {
     if (prbuf->lf) {
@@ -1021,13 +1023,13 @@ ulg gcf(ulg a, ulg b)
 
 
 
-int pngcheck(FILE *fp, char *fname, int searching, FILE *fpOut)
+int pngcheck(FILE *fp, const char *fname, int searching, FILE *fpOut)
 {
   unsigned int i, j;
   long sz;  /* FIXME:  should be ulg (not using negative values as flags...) */
   uch magic[8];
   char chunkid[5] = {'\0', '\0', '\0', '\0', '\0'};
-  char *and = "";
+  const char *and = "";
   int toread;
   int c;
   int have_IHDR = 0, have_IEND = 0;
@@ -1640,7 +1642,7 @@ FIXME: make sure bit 31 (0x80000000) is 0
           printf(": %d palette entr%s\n", nplte, nplte == 1? "y":"ies");
         }
         if (printpal) {
-          char *spc;
+          const char *spc;
 
           if (nplte < 10)
             spc = "  ";
@@ -2339,7 +2341,7 @@ FIXME: make sure bit 31 (0x80000000) is 0
                verbose? ":":fname, verbose? "":"hIST ");
         set_err(kMinorError);
       } else if (printpal && no_err(kMinorError)) {
-        char *spc;
+        const char *spc;
 
         if (sz < 10)
           spc = "  ";
@@ -2889,7 +2891,7 @@ FIXME: make sure bit 31 (0x80000000) is 0
           printf("\n");
         }
         if (printpal && no_err(kMinorError)) {
-          char *spc;
+          const char *spc;
           unsigned int i, j = name_len+2, jstep = ((bytes == 1) ? 6 : 10);
 
           if (nsplt < 10)
@@ -3163,7 +3165,7 @@ FIXME: add support for decompressing/printing zTXt
               printf(": %ld transparency entr%s\n", sz, sz == 1? "y":"ies");
             }
             if (printpal && no_err(kMinorError)) {
-              char *spc;
+              const char *spc;
 
               if (sz < 10)
                 spc = "  ";
@@ -4596,7 +4598,7 @@ FIXME: add support for decompressing/printing zTXt
           verbose? ":":fname, verbose? "":"PPLT ");
         set_err(kMinorError);
       } else {
-        char *plus;
+        const char *plus;
         uch dtype = buffer[0];
         uch first_idx = buffer[1];
         uch last_idx = buffer[2];
@@ -4910,7 +4912,7 @@ FIXME: add support for decompressing/printing zTXt
         int num_names = 0;
 
         while (bytes_left > 0) {
-          if (check_chunk_name((char *)buf, fname) != 0) {
+          if (check_chunk_name((const char *)buf, fname) != 0) {
             printf("%s  invalid chunk name to be dropped\n",
               verbose? ":":fname);
             set_err(kMinorError);
@@ -4948,7 +4950,7 @@ FIXME: add support for decompressing/printing zTXt
         printf("%s  invalid %spolarity (%u)\n",
           verbose? ":":fname, verbose? "":"DBYK ", buffer[4]);
         set_err(kMinorError);
-      } else if (check_chunk_name((char *)buffer, fname) != 0) {
+      } else if (check_chunk_name((const char *)buffer, fname) != 0) {
         printf("%s  invalid chunk name to be dropped\n",
           verbose? ":":fname);
         set_err(kMinorError);
@@ -4969,7 +4971,7 @@ FIXME: add support for decompressing/printing zTXt
           space_left -= buffer[4]? 18:15;   /* e.g., "cHNK: drop all but" */
         }
         while (bytes_left > 0) {
-          char *sep;
+          const char *sep;
           int keylen;
 
           if (check_keyword(buf, bytes_left, &keylen, "keyword", chunkid,
@@ -5030,7 +5032,7 @@ FIXME: add support for decompressing/printing zTXt
         if (verbose)
           printf("\n");
         while (bytes_left > 0) {
-          if (check_chunk_name((char *)buf, fname) != 0) {
+          if (check_chunk_name((const char *)buf, fname) != 0) {
             printf("%s  %slisted chunk name is invalid\n",
               verbose? ":":fname, verbose? "":"ORDR: ");
             set_err(kMinorError);
@@ -5287,7 +5289,7 @@ FIXME: add support for decompressing/printing zTXt
       }
 
     } else if (jng) {
-      char *sgn = "";
+      const char *sgn = "";
       int cfactor;
       ulg ucsize;
 
@@ -5328,7 +5330,7 @@ FIXME: add support for decompressing/printing zTXt
       }
 
     } else {
-      char *sgn = "";
+      const char *sgn = "";
       int cfactor;
 
       if (!did_stat)
@@ -5372,7 +5374,7 @@ FIXME: add support for decompressing/printing zTXt
 
 
 
-int pnginfile(FILE *fp, char *fname, int ipng, int extracting)
+int pnginfile(FILE *fp, const char *fname, int ipng, int extracting)
 {
   char name[1024], *szdot;
   int err = kOK;
@@ -5419,7 +5421,7 @@ int pnginfile(FILE *fp, char *fname, int ipng, int extracting)
 
 
 
-void pngsearch(FILE *fp, char *fname, int extracting)
+void pngsearch(FILE *fp, const char *fname, int extracting)
 {
   /* Go through the file looking for a PNG magic number; if one is
      found, check the data to see if it is a PNG and validate the
@@ -5474,7 +5476,7 @@ void pngsearch(FILE *fp, char *fname, int extracting)
  * without any restrictions.
  *
  */
-int check_magic(uch *magic, char *fname, int which)
+int check_magic(uch *magic, const char *fname, int which)
 {
   int i;
   const uch *good_magic = (which == 0)? good_PNG_magic :
@@ -5498,23 +5500,23 @@ int check_magic(uch *magic, char *fname, int which)
     printf("  File is CORRUPTED.  It seems to have suffered ");
 
     /* This coding derived from Alexander Lehmann's checkpng code   */
-    if (strncmp((char *)&magic[4], "\012\032", 2) == 0)
+    if (strncmp((const char *)&magic[4], "\012\032", 2) == 0)
       printf("DOS->Unix");
-    else if (strncmp((char *)&magic[4], "\015\032", 2) == 0)
+    else if (strncmp((const char *)&magic[4], "\015\032", 2) == 0)
       printf("DOS->Mac");
-    else if (strncmp((char *)&magic[4], "\015\015\032", 3) == 0)
+    else if (strncmp((const char *)&magic[4], "\015\015\032", 3) == 0)
       printf("Unix->Mac");
-    else if (strncmp((char *)&magic[4], "\012\012\032", 3) == 0)
+    else if (strncmp((const char *)&magic[4], "\012\012\032", 3) == 0)
       printf("Mac->Unix");
-    else if (strncmp((char *)&magic[4], "\012\012", 2) == 0)
+    else if (strncmp((const char *)&magic[4], "\012\012", 2) == 0)
       printf("DOS->Unix");
-    else if (strncmp((char *)&magic[4], "\015\015\012\032", 4) == 0)
+    else if (strncmp((const char *)&magic[4], "\015\015\012\032", 4) == 0)
       printf("Unix->DOS");
-    else if (strncmp((char *)&magic[4], "\015\012\032\015", 4) == 0)
+    else if (strncmp((const char *)&magic[4], "\015\012\032\015", 4) == 0)
       printf("Unix->DOS");
-    else if (strncmp((char *)&magic[4], "\015\012\012", 3) == 0)
+    else if (strncmp((const char *)&magic[4], "\015\012\012", 3) == 0)
       printf("DOS EOF");
-    else if (strncmp((char *)&magic[4], "\015\012\032\012", 4) != 0)
+    else if (strncmp((const char *)&magic[4], "\015\012\032\012", 4) != 0)
       printf("EOL");
     else
       printf("an unknown");
@@ -5535,7 +5537,7 @@ int check_magic(uch *magic, char *fname, int which)
 
 
 /* GRR 20061203:  now EBCDIC-safe */
-int check_chunk_name(char *chunk_name, char *fname)
+int check_chunk_name(const char *chunk_name, const char *fname)
 {
   if (isASCIIalpha((int)(uch)chunk_name[0]) &&
       isASCIIalpha((int)(uch)chunk_name[1]) &&
@@ -5557,7 +5559,7 @@ int check_chunk_name(char *chunk_name, char *fname)
 /* keyword_name is "keyword" for most chunks, but it can instead be "name" or
  * "identifier" or whatever makes sense for the chunk in question */
 int check_keyword(uch *buffer, int maxsize, int *pKeylen,
-                  char *keyword_name, char *chunkid, char *fname)
+          const char *keyword_name, const char *chunkid, const char *fname)
 {
   int j, prev_space = 0;
   int keylen = keywordlen(buffer, maxsize);
@@ -5617,7 +5619,7 @@ int check_keyword(uch *buffer, int maxsize, int *pKeylen,
 
 /* GRR 20070707 */
 /* caller must do set_err(kMinorError) based on return value (0 == OK) */
-int check_text(uch *buffer, int maxsize, char *chunkid, char *fname)
+int check_text(uch *buffer, int maxsize, const char *chunkid, const char *fname)
 {
   int j, ctrlwarn = verbose? 1 : 0;  /* print message once, only if verbose */
 
@@ -5640,7 +5642,8 @@ int check_text(uch *buffer, int maxsize, char *chunkid, char *fname)
 
 /* GRR 20061203 (used only for sCAL) */
 /* caller must do set_err(kMinorError) based on return value (0 == OK) */
-int check_ascii_float(uch *buffer, int len, char *chunkid, char *fname)
+int check_ascii_float(uch *buffer, int len, const char *chunkid,
+        const char *fname)
 {
   uch *qq = buffer, *bufEnd = buffer + len;
   int /* have_sign = 0, */ have_integer = 0, have_dot = 0, have_fraction = 0;


### PR DESCRIPTION
pngcheck.c: Changes all the (char *) declarations and definitions to
(const char *).  The code only uses (char *) for strings.

Signed-off-by: John Bowler <jbowler@acm.org>
