### PR TITLE
Code clean-up and simplification

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -3,7 +3,8 @@
                           Glenn Randers-Pehrson <randeg@alum.rpi.edu>,
                           Greg Roelofs <newt@pobox.com>,
                           John Bowler <jbowler@acm.org>,
-                          Tom Lane <tgl@sss.pgh.pa.us>
+                          Tom Lane <tgl@sss.pgh.pa.us>,
+                          Project Nayuki (https://www.nayuki.io/)
 
    Permission to use, copy, modify, and distribute this software and its
    documentation for any purpose and without fee is hereby granted, provided

--- a/pngcheck.c
+++ b/pngcheck.c
@@ -184,24 +184,24 @@ void usage (FILE *fpMsg);
 void make_crc_table (void);
 ulg  update_crc (ulg crc, uch *buf, int len);
 #endif
-ulg  getlong (FILE *fp, char *fname, char *where);
+ulg  getlong (FILE *fp, const char *fname, const char *where);
 void putlong (FILE *fpOut, ulg ul);
 void init_printbuf_state (printbuf_state *prbuf);
 void print_buffer (printbuf_state *prbuf, uch *buffer, int size, int indent);
-void report_printbuf (printbuf_state *prbuf, char *fname, char *chunkid);
+void report_printbuf (printbuf_state *prbuf, const char *fname, const char *chunkid);
 int  keywordlen (uch *buffer, int maxsize);
 const char *getmonth (int m);
 int  ratio (ulg uc, ulg c);
 ulg  gcf (ulg a, ulg b);
-int  pngcheck (FILE *fp, char *_fname, int searching, FILE *fpOut);
-int  pnginfile (FILE *fp, char *fname, int ipng, int extracting);
-void pngsearch (FILE *fp, char *fname, int extracting);
-int  check_magic (uch *magic, char *fname, int which);
-int  check_chunk_name (char *chunk_name, char *fname);
+int  pngcheck (FILE *fp, const char *_fname, int searching, FILE *fpOut);
+int  pnginfile (FILE *fp, const char *fname, int ipng, int extracting);
+void pngsearch (FILE *fp, const char *fname, int extracting);
+int  check_magic (uch *magic, const char *fname, int which);
+int  check_chunk_name (const char *chunk_name, const char *fname);
 int  check_keyword (uch *buffer, int maxsize, int *pKeylen,
-                    char *keyword_name, char *chunkid, char *fname);
-int  check_text (uch *buffer, int maxsize, char *chunkid, char *fname);
-int  check_ascii_float (uch *buffer, int len, char *chunkid, char *fname);
+                    const char *keyword_name, const char *chunkid, const char *fname);
+int  check_text (uch *buffer, int maxsize, const char *chunkid, const char *fname);
+int  check_ascii_float (uch *buffer, int len, const char *chunkid, const char *fname);
 char const * u2name_helper(unsigned int value, const char **names,
                            size_t nnames);
 
@@ -836,7 +836,7 @@ ulg update_crc(ulg crc, uch *buf, int len)
 
 
 
-ulg getlong(FILE *fp, char *fname, char *where)
+ulg getlong(FILE *fp, const char *fname, const char *where)
 {
   ulg res = 0;
   int j;
@@ -925,7 +925,7 @@ void print_buffer(printbuf_state *prbuf, uch *buf, int size, int indent)
 
 
 
-void report_printbuf(printbuf_state *prbuf, char *fname, char *chunkid)
+void report_printbuf(printbuf_state *prbuf, const char *fname, const char *chunkid)
 {
   if (prbuf->cr) {
     if (prbuf->lf) {
@@ -1017,7 +1017,7 @@ ulg gcf(ulg a, ulg b)
 
 
 
-int pngcheck(FILE *fp, char *fname, int searching, FILE *fpOut)
+int pngcheck(FILE *fp, const char *fname, int searching, FILE *fpOut)
 {
   int i, j;
   long sz;  /* FIXME:  should be ulg (not using negative values as flags...) */
@@ -4859,7 +4859,7 @@ FIXME: add support for decompressing/printing zTXt
 
 
 
-int pnginfile(FILE *fp, char *fname, int ipng, int extracting)
+int pnginfile(FILE *fp, const char *fname, int ipng, int extracting)
 {
   char name[1024], *szdot;
   int err = kOK;
@@ -4906,7 +4906,7 @@ int pnginfile(FILE *fp, char *fname, int ipng, int extracting)
 
 
 
-void pngsearch(FILE *fp, char *fname, int extracting)
+void pngsearch(FILE *fp, const char *fname, int extracting)
 {
   /* Go through the file looking for a PNG magic number; if one is
      found, check the data to see if it is a PNG and validate the
@@ -4961,7 +4961,7 @@ void pngsearch(FILE *fp, char *fname, int extracting)
  * without any restrictions.
  *
  */
-int check_magic(uch *magic, char *fname, int which)
+int check_magic(uch *magic, const char *fname, int which)
 {
   int i;
   const uch *good_magic = (which == 0)? good_PNG_magic :
@@ -5022,7 +5022,7 @@ int check_magic(uch *magic, char *fname, int which)
 
 
 /* GRR 20061203:  now EBCDIC-safe */
-int check_chunk_name(char *chunk_name, char *fname)
+int check_chunk_name(const char *chunk_name, const char *fname)
 {
   if (isASCIIalpha((int)(uch)chunk_name[0]) &&
       isASCIIalpha((int)(uch)chunk_name[1]) &&
@@ -5044,7 +5044,7 @@ int check_chunk_name(char *chunk_name, char *fname)
 /* keyword_name is "keyword" for most chunks, but it can instead be "name" or
  * "identifier" or whatever makes sense for the chunk in question */
 int check_keyword(uch *buffer, int maxsize, int *pKeylen,
-                  char *keyword_name, char *chunkid, char *fname)
+                  const char *keyword_name, const char *chunkid, const char *fname)
 {
   int j, prev_space = 0;
   int keylen = keywordlen(buffer, maxsize);
@@ -5104,7 +5104,7 @@ int check_keyword(uch *buffer, int maxsize, int *pKeylen,
 
 /* GRR 20070707 */
 /* caller must do set_err(kMinorError) based on return value (0 == OK) */
-int check_text(uch *buffer, int maxsize, char *chunkid, char *fname)
+int check_text(uch *buffer, int maxsize, const char *chunkid, const char *fname)
 {
   int j, ctrlwarn = verbose? 1 : 0;  /* print message once, only if verbose */
 
@@ -5127,7 +5127,7 @@ int check_text(uch *buffer, int maxsize, char *chunkid, char *fname)
 
 /* GRR 20061203 (used only for sCAL) */
 /* caller must do set_err(kMinorError) based on return value (0 == OK) */
-int check_ascii_float(uch *buffer, int len, char *chunkid, char *fname)
+int check_ascii_float(uch *buffer, int len, const char *chunkid, const char *fname)
 {
   uch *qq = buffer, *bufEnd = buffer + len;
   int /* have_sign = 0, */ have_integer = 0, have_dot = 0, have_fraction = 0;

--- a/pngcheck.c
+++ b/pngcheck.c
@@ -258,10 +258,6 @@ bool is_public(const char *chunkID) {
   return !is_private(chunkID);
 }
 
-#define set_err(x)  global_error = ((global_error < (x))? (x) : global_error)
-#define is_err(x)   (global_error >= (x))
-#define no_err(x)   (global_error < (x))
-
 enum Error {
   kOK = 0,
   kWarning,           /* could be an error in some circumstances but not all */
@@ -270,6 +266,12 @@ enum Error {
   kMajorError,        /* file corruption, invalid chunk length/layout, etc. */
   kCriticalError      /* unexpected EOF or other file(system) error */
 };
+
+enum Error global_error = kOK; /* the current error status */
+
+#define set_err(x)  global_error = ((global_error < (x))? (x) : global_error)
+#define is_err(x)   (global_error >= (x))
+#define no_err(x)   (global_error < (x))
 
 /* Command-line flag variables */
 int verbose = 0;	/* print chunk info */
@@ -286,7 +288,6 @@ bool png = false;		/* it's a PNG */
 bool mng = false;		/* it's a MNG instead of a PNG (won't work in pipe) */
 bool jng = false;		/* it's a JNG */
 
-enum Error global_error = kOK; /* the current error status */
 uch buffer[BS];
 
 /* what the PNG, MNG and JNG magic numbers should be */

--- a/pngcheck.c
+++ b/pngcheck.c
@@ -331,7 +331,7 @@ static const uch latin1_text_discouraged[256] = {
    const char *color_off;
 #else
    ulg crc_table[256];           /* table of CRCs of all 8-bit messages */
-   int crc_table_computed = 0;   /* flag:  has the table been computed? */
+   bool crc_table_computed = false;   /* flag:  has the table been computed? */
 #endif
 
 
@@ -808,7 +808,7 @@ void make_crc_table(void)
 
     crc_table[n] = c;
   }
-  crc_table_computed = 1;
+  crc_table_computed = true;
 }
 
 
@@ -5048,7 +5048,8 @@ int check_chunk_name(const char *chunk_name, const char *fname)
 int check_keyword(const uch *buffer, int maxsize, int *pKeylen,
                   const char *keyword_name, const char *chunkid, const char *fname)
 {
-  int j, prev_space = 0;
+  int j;
+  bool prev_space = false;
   int keylen = keywordlen(buffer, maxsize);
 
   if (pKeylen)
@@ -5085,9 +5086,9 @@ int check_keyword(const uch *buffer, int maxsize, int *pKeylen,
           verbose? ":":fname, verbose? "":chunkid, keyword_name);
         return 5;
       }
-      prev_space = 1;
+      prev_space = true;
     } else {
-      prev_space = 0;
+      prev_space = false;
     }
   }
 
@@ -5108,7 +5109,8 @@ int check_keyword(const uch *buffer, int maxsize, int *pKeylen,
 /* caller must do set_err(kMinorError) based on return value (0 == OK) */
 int check_text(const uch *buffer, int maxsize, const char *chunkid, const char *fname)
 {
-  int j, ctrlwarn = verbose? 1 : 0;  /* print message once, only if verbose */
+  int j;
+  bool ctrlwarn = verbose != 0;  /* print message once, only if verbose */
 
   for (j = 0; j < maxsize; ++j) {
     if (buffer[j] == 0) {
@@ -5118,7 +5120,7 @@ int check_text(const uch *buffer, int maxsize, const char *chunkid, const char *
     } else if (ctrlwarn && latin1_text_discouraged[buffer[j]]) {
       printf(":   text has control character(s) (%u) (discouraged)\n",
         buffer[j]);
-      ctrlwarn = 0;
+      ctrlwarn = false;
     }
   }
 

--- a/pngcheck.c
+++ b/pngcheck.c
@@ -1027,15 +1027,15 @@ int pngcheck(FILE *fp, const char *fname, int searching, FILE *fpOut)
   char *and = "";
   int toread;
   int c;
-  int have_IHDR = 0, have_IEND = 0;
-  int have_MHDR = 0, have_MEND = 0;
-  int /* have_DHDR = 0, */ have_PLTE = 0;
-  int have_JHDR = 0, have_JSEP = 0, need_JSEP = 0;
+  bool have_IHDR = false, have_IEND = false;
+  bool have_MHDR = false, have_MEND = false;
+  bool /* have_DHDR = false, */ have_PLTE = false;
+  bool have_JHDR = false, have_JSEP = false, need_JSEP = false;
   int have_IDAT = 0, have_JDAT = 0, last_is_IDAT = 0, last_is_JDAT = 0;
-  int have_bKGD = 0, have_cHRM = 0, have_eXIf = 0, have_gAMA = 0, have_hIST = 0;
-  int have_iCCP = 0, have_oFFs = 0, have_pCAL = 0, have_pHYs = 0, have_sBIT = 0;
-  int have_sCAL = 0, have_sRGB = 0, have_sTER = 0, have_tIME = 0, have_tRNS = 0;
-  int have_SAVE = 0, have_TERM = 0, have_MAGN = 0, have_pHYg = 0;
+  bool have_bKGD = false, have_cHRM = false, have_eXIf = false, have_gAMA = false, have_hIST = false;
+  bool have_iCCP = false, have_oFFs = false, have_pCAL = false, have_pHYs = false, have_sBIT = false;
+  bool have_sCAL = false, have_sRGB = false, have_sTER = false, have_tIME = false, have_tRNS = false;
+  bool have_SAVE = false, have_TERM = false, have_MAGN = false, have_pHYg = false;
   int top_level = 1;
   ulg zhead = 1;   /* 0x10000 indicates both zlib header bytes read */
   ulg crc, filecrc;
@@ -1311,7 +1311,7 @@ int pngcheck(FILE *fp, const char *fname, int searching, FILE *fpOut)
             bitdepth, U2NAME(ityp, png_type), lace? "":"non-");
         }
       }
-      have_IHDR = 1;
+      have_IHDR = true;
       if (mng)
         top_level = 0;
       last_is_IDAT = last_is_JDAT = 0;
@@ -1382,7 +1382,7 @@ int pngcheck(FILE *fp, const char *fname, int searching, FILE *fpOut)
             int a;
 
             if (bitdepth == 20) {
-              need_JSEP = 1;
+              need_JSEP = true;
               jbitd = 8;
               and = "and 12-bit ";
             } else
@@ -1408,7 +1408,7 @@ int pngcheck(FILE *fp, const char *fname, int searching, FILE *fpOut)
           }
         }
       }
-      have_JHDR = 1;
+      have_JHDR = true;
       if (mng)
         top_level = 0;
       last_is_IDAT = last_is_JDAT = 0;
@@ -1569,7 +1569,7 @@ FIXME: make sure bit 31 (0x80000000) is 0
               profile? "invalid" : "unspecified");
         }
       }
-      have_MHDR = 1;
+      have_MHDR = true;
       last_is_IDAT = last_is_JDAT = 0;
 
     /*================================================*
@@ -1639,7 +1639,7 @@ FIXME: make sure bit 31 (0x80000000) is 0
                    buffer[j], buffer[j + 1], buffer[j + 2]);
         }
       }
-      have_PLTE = 1;
+      have_PLTE = true;
       last_is_IDAT = last_is_JDAT = 0;
 
     /*------*
@@ -2023,7 +2023,7 @@ FIXME: make sure bit 31 (0x80000000) is 0
       } else if (verbose) {
         printf("\n");
       }
-      have_IEND = 1;
+      have_IEND = true;
       last_is_IDAT = last_is_JDAT = 0;
 
     /*------*
@@ -2078,7 +2078,7 @@ FIXME: make sure bit 31 (0x80000000) is 0
           }
           break;
       }
-      have_bKGD = 1;
+      have_bKGD = true;
       last_is_IDAT = last_is_JDAT = 0;
 
     /*------*
@@ -2141,7 +2141,7 @@ FIXME: make sure bit 31 (0x80000000) is 0
                  gx, gy, bx, by);
         }
       }
-      have_cHRM = 1;
+      have_cHRM = true;
       last_is_IDAT = last_is_JDAT = 0;
 
     /*------*
@@ -2165,7 +2165,7 @@ FIXME: make sure bit 31 (0x80000000) is 0
                  buffer[0], buffer[1], buffer[2], buffer[3]);
         }
       }
-      have_eXIf = 1;
+      have_eXIf = true;
       last_is_IDAT = last_is_JDAT = 0;
 
     /*------*
@@ -2209,7 +2209,7 @@ FIXME: make sure bit 31 (0x80000000) is 0
       if (verbose && no_err(kMinorError)) {
         printf(": %#0.5g\n", (double)LG(buffer)/100000);
       }
-      have_gAMA = 1;
+      have_gAMA = true;
       last_is_IDAT = last_is_JDAT = 0;
 
     /*------*
@@ -2323,7 +2323,7 @@ FIXME: make sure bit 31 (0x80000000) is 0
         for (i = j = 0;  j < sz;  ++i, j += 2)
           printf("%s%3d:  %5u\n", spc, i, SH(buffer+j));
       }
-      have_hIST = 1;
+      have_hIST = true;
       last_is_IDAT = last_is_JDAT = 0;
 
     /*------*
@@ -2381,7 +2381,7 @@ FIXME: make sure bit 31 (0x80000000) is 0
                                       /* FIXME: should use remainder instead? */
         }
       }
-      have_iCCP = 1;
+      have_iCCP = true;
       last_is_IDAT = last_is_JDAT = 0;
 
     /*------*
@@ -2474,7 +2474,7 @@ FIXME: make sure bit 31 (0x80000000) is 0
         printf(": %ldx%ld %s offset\n", LG(buffer), LG(buffer+4),
                (buffer[8] == 0)? "pixels":"micrometers");
       }
-      have_oFFs = 1;
+      have_oFFs = true;
       last_is_IDAT = last_is_JDAT = 0;
 
     /*------*
@@ -2578,7 +2578,7 @@ FIXME: make sure bit 31 (0x80000000) is 0
           }
         }
       }
-      have_pCAL = 1;
+      have_pCAL = true;
       last_is_IDAT = last_is_JDAT = 0;
 
     /*------*
@@ -2616,7 +2616,7 @@ FIXME: make sure bit 31 (0x80000000) is 0
         }
         printf("\n");
       }
-      have_pHYs = 1;
+      have_pHYs = true;
       last_is_IDAT = last_is_JDAT = 0;
 
     /*------*
@@ -2724,7 +2724,7 @@ FIXME: make sure bit 31 (0x80000000) is 0
           }
           break;
       }
-      have_sBIT = 1;
+      have_sBIT = true;
       last_is_IDAT = last_is_JDAT = 0;
 
     /*------*
@@ -2807,7 +2807,7 @@ FIXME: make sure bit 31 (0x80000000) is 0
         printf(": image size %s x %s %s\n", pPixwidth, pPixheight,
                (unittype == 1)? "meters":"radians");
       }
-      have_sCAL = 1;
+      have_sCAL = true;
       last_is_IDAT = last_is_JDAT = 0;
 
     /*------*
@@ -2934,7 +2934,7 @@ FIXME: make sure bit 31 (0x80000000) is 0
         printf("\n    rendering intent = %s\n",
                U2NAME(buffer[0], rendering_intent));
       }
-      have_sRGB = 1;
+      have_sRGB = true;
       last_is_IDAT = last_is_JDAT = 0;
 
     /*------*
@@ -2961,7 +2961,7 @@ FIXME: make sure bit 31 (0x80000000) is 0
         printf("\n    stereo subimage layout = %s\n",
                buffer[0]? "divergent (parallel)":"cross-eyed");
       }
-      have_sTER = 1;
+      have_sTER = true;
       last_is_IDAT = last_is_JDAT = 0;
 
     /*------*  *------*
@@ -3079,7 +3079,7 @@ FIXME: add support for decompressing/printing zTXt
             hh, mm, ss);
         }
       }
-      have_tIME = 1;
+      have_tIME = true;
       last_is_IDAT = last_is_JDAT = 0;
 
     /*------*
@@ -3156,7 +3156,7 @@ FIXME: add support for decompressing/printing zTXt
             break;
         }
       }
-      have_tRNS = 1;
+      have_tRNS = true;
       last_is_IDAT = last_is_JDAT = 0;
 
     /*===========================================*/
@@ -3310,7 +3310,7 @@ FIXME: add support for decompressing/printing zTXt
       } else if (verbose) {
         printf("\n");
       }
-      have_JSEP = 1;
+      have_JSEP = true;
       last_is_IDAT = 0;
       last_is_JDAT = 1;   /* effectively... (GRR HACK) */
 
@@ -3357,7 +3357,7 @@ FIXME: add support for decompressing/printing zTXt
           }
         }
       }
-      //have_DHDR = 1;
+      //have_DHDR = true;
       last_is_IDAT = last_is_JDAT = 0;
 #ifdef USE_ZLIB
       first_idat = 1;  /* flag:  next IDAT will be the first in this subimage */
@@ -3576,7 +3576,7 @@ FIXME: add support for decompressing/printing zTXt
       } else if (verbose) {
         printf("\n");
       }
-      have_SAVE = 1;
+      have_SAVE = true;
       last_is_IDAT = last_is_JDAT = 0;
 
     /*------*
@@ -4300,7 +4300,7 @@ FIXME: add support for decompressing/printing zTXt
             printf("%lu\n", val);
         }
       }
-      have_TERM = 1;
+      have_TERM = true;
       last_is_IDAT = last_is_JDAT = 0;
 
     /*------*
@@ -4380,7 +4380,7 @@ FIXME: add support for decompressing/printing zTXt
           printf("\n");
         }
       }
-      have_pHYg = 1;
+      have_pHYg = true;
       last_is_IDAT = last_is_JDAT = 0;
 
     /*------*
@@ -4629,7 +4629,7 @@ FIXME: add support for decompressing/printing zTXt
           }
         }
       }
-      have_MAGN = 1;
+      have_MAGN = true;
       last_is_IDAT = last_is_JDAT = 0;
 
     /*------*
@@ -4650,7 +4650,7 @@ FIXME: add support for decompressing/printing zTXt
       } else if (verbose) {
         printf("\n");
       }
-      have_MEND = 1;
+      have_MEND = true;
       last_is_IDAT = last_is_JDAT = 0;
 
     /*===============*

--- a/pngcheck.c
+++ b/pngcheck.c
@@ -261,18 +261,18 @@ enum Error {
 
 /* Command-line flag variables */
 int verbose = 0;	/* print chunk info */
-int quiet = 0;		/* print only error messages */
-int printtext = 0;	/* print tEXt chunks */
-int printpal = 0;	/* print PLTE/tRNS/hIST/sPLT contents */
-int color = 0;		/* print with ANSI colors to spice things up */
-int sevenbit = 0;	/* escape characters >=160 */
-int check_windowbits = 1;	/* more stringent zlib stream-checking */
-int suppress_warnings = 0;	/* don't fuss about ambiguous stuff */
-int search = 0;		/* hunt for PNGs in the file... */
-int extract = 0;	/* ...and extract them to arbitrary file names. */
-int png = 0;		/* it's a PNG */
-int mng = 0;		/* it's a MNG instead of a PNG (won't work in pipe) */
-int jng = 0;		/* it's a JNG */
+bool quiet = false;		/* print only error messages */
+bool printtext = false;	/* print tEXt chunks */
+bool printpal = false;	/* print PLTE/tRNS/hIST/sPLT contents */
+bool color = false;		/* print with ANSI colors to spice things up */
+bool sevenbit = false;	/* escape characters >=160 */
+bool check_windowbits = true;	/* more stringent zlib stream-checking */
+bool suppress_warnings = false;	/* don't fuss about ambiguous stuff */
+bool search = false;		/* hunt for PNGs in the file... */
+bool extract = false;	/* ...and extract them to arbitrary file names. */
+bool png = false;		/* it's a PNG */
+bool mng = false;		/* it's a MNG instead of a PNG (won't work in pipe) */
+bool jng = false;		/* it's a JNG */
 
 enum Error global_error = kOK; /* the current error status */
 uch buffer[BS];
@@ -582,45 +582,45 @@ int main(int argc, char *argv[])
         i = 1;
         break;
       case '7':
-        printtext = 1;
-        sevenbit = 1;
+        printtext = true;
+        sevenbit = true;
         ++i;
         break;
       case 'c':
-        color = 1;
+        color = true;
         ++i;
         break;
       case 'h':
         usage(stdout);
         return err;
       case 'p':
-        printpal = 1;
+        printpal = true;
         ++i;
         break;
       case 'q':
         verbose = 0;
-        quiet = 1;
+        quiet = true;
         ++i;
         break;
       case 's':
-        search = 1;
+        search = true;
         ++i;
         break;
       case 't':
-        printtext = 1;
+        printtext = true;
         ++i;
         break;
       case 'v':
         ++verbose;  /* verbose == 2 means decode IDATs and print filter info */
-        quiet = 0;  /* verbose == 4 means print pixel values, too */
+        quiet = false;  /* verbose == 4 means print pixel values, too */
         ++i;
         break;
       case 'w':
-        check_windowbits = 0;
+        check_windowbits = false;
         ++i;
         break;
       case 'x':
-        search = extract = 1;
+        search = extract = true;
         ++i;
         break;
       default:
@@ -1072,7 +1072,7 @@ int pngcheck(FILE *fp, const char *fname, int searching, FILE *fpOut)
   }
 
   first_file = 0;
-  png = mng = jng = 0;
+  png = mng = jng = false;
 
   if (!searching) {
     int check = 0;
@@ -1091,15 +1091,15 @@ int pngcheck(FILE *fp, const char *fname, int searching, FILE *fpOut)
         printf("    cannot read past MacBinary header\n");
         set_err(kCriticalError);
       } else if ((check = check_magic(magic, fname, DO_PNG)) == 0) {
-        png = 1;
+        png = true;
         if (!quiet)
           printf("    this PNG seems to be contained in a MacBinary file\n");
       } else if ((check = check_magic(magic, fname, DO_MNG)) == 0) {
-        mng = 1;
+        mng = true;
         if (!quiet)
           printf("    this MNG seems to be contained in a MacBinary file\n");
       } else if ((check = check_magic(magic, fname, DO_JNG)) == 0) {
-        jng = 1;
+        jng = true;
         if (!quiet)
           printf("    this JNG seems to be contained in a MacBinary file\n");
       } else {
@@ -1108,14 +1108,14 @@ int pngcheck(FILE *fp, const char *fname, int searching, FILE *fpOut)
         set_err(kCriticalError);
       }
     } else if ((check = check_magic(magic, fname, DO_PNG)) == 0) {
-      png = 1;
+      png = true;
     } else if (check == 1) {   /* bytes 2-4 == "PNG" but others are bad */
       set_err(kCriticalError);
     } else if (check == 2) {   /* not "PNG"; see if it's MNG or JNG instead */
       if ((check = check_magic(magic, fname, DO_MNG)) == 0)
-        mng = 1;        /* yup */
+        mng = true;        /* yup */
       else if (check == 2 && (check = check_magic(magic, fname, DO_JNG)) == 0)
-        jng = 1;        /* yup */
+        jng = true;        /* yup */
       else {
         set_err(kCriticalError);
         if (check == 2)

--- a/pngcheck.c
+++ b/pngcheck.c
@@ -5132,9 +5132,9 @@ int check_text(const uch *buffer, int maxsize, const char *chunkid, const char *
 int check_ascii_float(const uch *buffer, int len, const char *chunkid, const char *fname)
 {
   const uch *qq = buffer, *bufEnd = buffer + len;
-  int /* have_sign = 0, */ have_integer = 0, have_dot = 0, have_fraction = 0;
-  int have_E = 0, have_Esign = 0, have_exponent = 0, in_digits = 0;
-  int have_nonzero = 0;
+  bool /* have_sign = false, */ have_integer = false, have_dot = false, have_fraction = false;
+  bool have_E = false, have_Esign = false, have_exponent = false, in_digits = false;
+  bool have_nonzero = false;
   int rc = 0;
 
   for (qq = buffer;  qq < bufEnd && !rc;  ++qq) {
@@ -5142,11 +5142,11 @@ int check_ascii_float(const uch *buffer, int len, const char *chunkid, const cha
       case '+':
       case '-':
         if (qq == buffer) {
-          //have_sign = 1;
-          in_digits = 0;
+          //have_sign = true;
+          in_digits = false;
         } else if (have_E && !have_Esign) {
-          have_Esign = 1;
-          in_digits = 0;
+          have_Esign = true;
+          in_digits = false;
         } else {
           printf("%s  invalid sign character%s%s (buf[%td])\n",
             verbose? ":":fname, verbose? "":" in ", verbose? "":chunkid,
@@ -5157,8 +5157,8 @@ int check_ascii_float(const uch *buffer, int len, const char *chunkid, const cha
 
       case '.':
         if (!have_dot && !have_E) {
-          have_dot = 1;
-          in_digits = 0;
+          have_dot = true;
+          in_digits = false;
         } else {
           printf("%s  invalid decimal point%s%s (buf[%td])\n",
             verbose? ":":fname, verbose? "":" in ", verbose? "":chunkid,
@@ -5170,8 +5170,8 @@ int check_ascii_float(const uch *buffer, int len, const char *chunkid, const cha
       case 'e':
       case 'E':
         if (have_integer || have_fraction) {
-          have_E = 1;
-          in_digits = 0;
+          have_E = true;
+          in_digits = false;
         } else {
           printf("%s  invalid exponent before mantissa%s%s (buf[%td])\n",
             verbose? ":":fname, verbose? "":" in ", verbose? "":chunkid,
@@ -5189,20 +5189,20 @@ int check_ascii_float(const uch *buffer, int len, const char *chunkid, const cha
         } else if (in_digits) {
           /* still in digits:  do nothing except check for non-zero digits */
           if (!have_exponent && *qq != '0')
-            have_nonzero = 1;
+            have_nonzero = true;
         } else if (!have_integer && !have_dot) {
-          have_integer = 1;
-          in_digits = 1;
+          have_integer = true;
+          in_digits = true;
           if (*qq != '0')
-            have_nonzero = 1;
+            have_nonzero = true;
         } else if (have_dot && !have_fraction) {
-          have_fraction = 1;
-          in_digits = 1;
+          have_fraction = true;
+          in_digits = true;
           if (*qq != '0')
-            have_nonzero = 1;
+            have_nonzero = true;
         } else if (have_E && !have_exponent) {
-          have_exponent = 1;
-          in_digits = 1;
+          have_exponent = true;
+          in_digits = true;
         } else {
           /* is this case possible? */
           printf("%s  invalid digits%s%s (buf[%td])\n",

--- a/pngcheck.c
+++ b/pngcheck.c
@@ -195,8 +195,8 @@ const char *getmonth (int m);
 int  ratio (ulg uc, ulg c);
 ulg  gcf (ulg a, ulg b);
 int  pngcheck (FILE *fp, const char *_fname, int searching, FILE *fpOut);
-int  pnginfile (FILE *fp, const char *fname, int ipng, int extracting);
-void pngsearch (FILE *fp, const char *fname, int extracting);
+int  pnginfile (FILE *fp, const char *fname, int ipng, bool extracting);
+void pngsearch (FILE *fp, const char *fname, bool extracting);
 int  check_magic (const uch *magic, const char *fname, int which);
 int  check_chunk_name (const char *chunk_name, const char *fname);
 int  check_keyword (const uch *buffer, int maxsize, int *pKeylen,
@@ -4861,7 +4861,7 @@ FIXME: add support for decompressing/printing zTXt
 
 
 
-int pnginfile(FILE *fp, const char *fname, int ipng, int extracting)
+int pnginfile(FILE *fp, const char *fname, int ipng, bool extracting)
 {
   char name[1024], *szdot;
   enum Error err = kOK;
@@ -4908,7 +4908,7 @@ int pnginfile(FILE *fp, const char *fname, int ipng, int extracting)
 
 
 
-void pngsearch(FILE *fp, const char *fname, int extracting)
+void pngsearch(FILE *fp, const char *fname, bool extracting)
 {
   /* Go through the file looking for a PNG magic number; if one is
      found, check the data to see if it is a PNG and validate the

--- a/pngcheck.c
+++ b/pngcheck.c
@@ -306,17 +306,10 @@ bool is_ascii_alpha(uch x) {
   return (0x41 <= x && x <= 0x5A) || (0x61 <= x && x <= 0x7A);
 }
 
-/* GRR 20070707:  list of forbidden characters in various keywords */
-static const uch latin1_keyword_forbidden[256] = {
-  1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
-  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,
-  1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
-  1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0 
-};
+/* list of forbidden characters in various keywords */
+bool is_latin1_keyword_forbidden(uch x) {
+  return (0x00 <= x && x <= 0x1F) || (0x7F <= x && x <= 0xA0);
+}
 
 /* GRR 20070707:  list of discouraged (control) characters in tEXt/zTXt text */
 static const uch latin1_text_discouraged[256] = {
@@ -5103,7 +5096,7 @@ int check_keyword(const uch *buffer, int maxsize, int *pKeylen,
   }
 
   for (j = 0; j < keylen; ++j) {
-    if (latin1_keyword_forbidden[buffer[j]]) {   /* [0,31] || [127,160] */
+    if (is_latin1_keyword_forbidden(buffer[j])) {   /* [0,31] || [127,160] */
       printf("%s  %s %s has control character(s) (%u)\n",
         verbose? ":":fname, verbose? "":chunkid, keyword_name, buffer[j]);
       return 6;

--- a/pngcheck.c
+++ b/pngcheck.c
@@ -1228,7 +1228,7 @@ int pngcheck(FILE *fp, const char *fname, int searching, FILE *fpOut)
         }
         bitdepth = sampledepth = (uch)buffer[8];
         ityp = (uch)buffer[9];
-        if (ityp == 1 || ityp == 5 || ityp > sizeof(png_type)/sizeof(char*)) {
+        if (ityp == 1 || ityp == 5 || (uch)ityp > sizeof(png_type)/sizeof(char*)) {
           printf("%s  invalid %simage type (%d)\n",
             verbose? ":":fname, verbose? "":"IHDR ", ityp);
           ityp = 1; /* avoid out of range array index */
@@ -3983,7 +3983,7 @@ FIXME: add support for decompressing/printing zTXt
         }
         bitdepth = (uch)buffer[8];
         ityp = (uch)buffer[9];
-        if (ityp > sizeof(png_type)/sizeof(char*)) {
+        if ((uch)ityp > sizeof(png_type)/sizeof(char*)) {
           ityp = 1; /* avoid out of range array index */
         }
         switch (bitdepth) {

--- a/pngcheck.c
+++ b/pngcheck.c
@@ -22,7 +22,8 @@
  *                          Glenn Randers-Pehrson <randeg@alum.rpi.edu>,
  *                          Greg Roelofs <newt@pobox.com>,
  *                          John Bowler <jbowler@acm.org>,
- *                          Tom Lane <tgl@sss.pgh.pa.us>
+ *                          Tom Lane <tgl@sss.pgh.pa.us>,
+ *                          Project Nayuki (https://www.nayuki.io/)
  *
  *   Permission to use, copy, modify, and distribute this software and its
  *   documentation for any purpose and without fee is hereby granted, provided

--- a/pngcheck.c
+++ b/pngcheck.c
@@ -130,6 +130,7 @@
  * pngcheck sources:	http://www.libpng.org/pub/png/apps/pngcheck.html
  */
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <ctype.h>
@@ -171,11 +172,11 @@ typedef unsigned long  ulg;
 
 /* printbuf state variables */
 typedef struct printbuf_state {
-  int cr;
-  int lf;
-  int nul;
-  int control;
-  int esc;
+  bool cr;
+  bool lf;
+  bool nul;
+  bool control;
+  bool esc;
 } printbuf_state;
 
 /* int  main (int argc, char *argv[]); */
@@ -875,11 +876,11 @@ void putlong(FILE *fpOut, ulg ul)
 
 void init_printbuf_state(printbuf_state *prbuf)
 {
-  prbuf->cr = 0;
-  prbuf->lf = 0;
-  prbuf->nul = 0;
-  prbuf->control = 0;
-  prbuf->esc = 0;
+  prbuf->cr = false;
+  prbuf->lf = false;
+  prbuf->nul = false;
+  prbuf->control = false;
+  prbuf->esc = false;
 }
 
 
@@ -908,17 +909,17 @@ void print_buffer(printbuf_state *prbuf, const uch *buf, int size, int indent)
 
     if (c < 32 || (c >= 127 && c < 160)) {
       if (c == '\n') {
-        prbuf->lf = 1;
+        prbuf->lf = true;
         if (indent && size > 0)
           printf("    ");
       } else if (c == '\r')
-        prbuf->cr = 1;
+        prbuf->cr = true;
       else if (c == '\0')
-        prbuf->nul = 1;
+        prbuf->nul = true;
       else
-        prbuf->control = 1;
+        prbuf->control = true;
       if (c == 27)
-        prbuf->esc = 1;
+        prbuf->esc = true;
     }
   }
 }

--- a/pngcheck.c
+++ b/pngcheck.c
@@ -234,7 +234,6 @@ char const * u2name_helper(unsigned int value, const char **names,
 #define COLOR_WHITE_BOLD    "\033[40;37;1m"	/* filenames, filter seps */
 #define COLOR_WHITE         "\033[40;37m"
 
-#define isASCIIalpha(x)     (ascii_alpha_table[x] & 0x1)
 /* Map unsigned value to enumerated string name, safely with fallback */
 #define U2NAME(x, names) (u2name_helper(x, &names[0], \
                                         sizeof(names) / sizeof(names[0])))
@@ -302,19 +301,10 @@ static const uch good_PNG_magic[8] = {137, 80, 78, 71, 13, 10, 26, 10};
 static const uch good_MNG_magic[8] = {138, 77, 78, 71, 13, 10, 26, 10};
 static const uch good_JNG_magic[8] = {139, 74, 78, 71, 13, 10, 26, 10};
 
-/* GRR FIXME:  could merge all three of these into single table (bit fields) */
-
-/* GRR 20061203:  for "isalpha()" that works even on EBCDIC machines */
-static const uch ascii_alpha_table[256] = {
-  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-  0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,0,0,0,0,0,
-  0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,0,0,0,0,0,
-  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0 
-};
+bool is_ascii_alpha(uch x) {
+  // ASCII character codes: 'A', 'Z', 'a', 'Z'
+  return (0x41 <= x && x <= 0x5A) || (0x61 <= x && x <= 0x7A);
+}
 
 /* GRR 20070707:  list of forbidden characters in various keywords */
 static const uch latin1_keyword_forbidden[256] = {
@@ -5046,10 +5036,10 @@ int check_magic(const uch *magic, const char *fname, int which)
 /* GRR 20061203:  now EBCDIC-safe */
 int check_chunk_name(const char *chunk_name, const char *fname)
 {
-  if (isASCIIalpha((int)(uch)chunk_name[0]) &&
-      isASCIIalpha((int)(uch)chunk_name[1]) &&
-      isASCIIalpha((int)(uch)chunk_name[2]) &&
-      isASCIIalpha((int)(uch)chunk_name[3]))
+  if (is_ascii_alpha((uch)chunk_name[0]) &&
+      is_ascii_alpha((uch)chunk_name[1]) &&
+      is_ascii_alpha((uch)chunk_name[2]) &&
+      is_ascii_alpha((uch)chunk_name[3]))
     return 0;
 
   printf("%s%s  invalid chunk name \"%.*s\" (%02x %02x %02x %02x)\n",

--- a/pngcheck.c
+++ b/pngcheck.c
@@ -269,9 +269,16 @@ enum Error {
 
 enum Error global_error = kOK; /* the current error status */
 
-#define set_err(x)  global_error = ((global_error < (x))? (x) : global_error)
-#define is_err(x)   (global_error >= (x))
-#define no_err(x)   (global_error < (x))
+void set_err(enum Error x) {
+  if (global_error < x)
+    global_error = x;
+}
+bool is_err(enum Error x) {
+  return global_error >= x;
+}
+bool no_err(enum Error x) {
+  return global_error < x;
+}
 
 /* Command-line flag variables */
 int verbose = 0;	/* print chunk info */

--- a/pngcheck.c
+++ b/pngcheck.c
@@ -2745,7 +2745,7 @@ FIXME: make sure bit 31 (0x80000000) is 0
                verbose? ":":fname, verbose? "":"sCAL ");
         set_err(kMinorError);
       } else if (sz > BS) {
-	/* FIXME: large sCAL chunks are unusual, but should be supported */
+        /* FIXME: large sCAL chunks are unusual, but should be supported */
         printf("%s  checking large %schunk not currently supported\n",
                verbose? ":":fname, verbose? "":"sCAL ");
         set_err(kMinorError);
@@ -2775,7 +2775,7 @@ FIXME: make sure bit 31 (0x80000000) is 0
           if (pPixheight == NULL) {
             /* missing pixel height, but -f was given */
             pPixheight = buffer+sz;
-	  }
+          }
           for (qq = pPixheight;  qq < buffer+sz;  ++qq) {
             if (*qq == 0)
               break;
@@ -2786,7 +2786,7 @@ FIXME: make sure bit 31 (0x80000000) is 0
             set_err(kWarning);
           }
           if (*pPixwidth == '-' ||
-	      (pPixheight != buffer+sz && *pPixheight == '-')) {
+              (pPixheight != buffer+sz && *pPixheight == '-')) {
             printf("%s  invalid negative %svalue(s)\n",
                    verbose? ":":fname, verbose? "":"sCAL ");
             set_err(kMinorError);
@@ -2876,7 +2876,7 @@ FIXME: make sure bit 31 (0x80000000) is 0
             spc = "      ";
 
           /* TODO: Support larger sPLT contents with an input-reading loop */
-	  if (nsplt > (BS - j) / jstep) {
+          if (nsplt > (BS - j) / jstep) {
             printf("%s  printing truncated %scontents\n",
               verbose? ":":fname, verbose? "":"sPLT ");
             nsplt = (BS - j) / jstep;
@@ -3377,7 +3377,7 @@ FIXME: add support for decompressing/printing zTXt
       } else if (sz == 0 && verbose) {
         printf(":  empty\n");
       } else if (sz > BS) {
-	/* FIXME: large FRAM chunks are unusual, but should be supported */
+        /* FIXME: large FRAM chunks are unusual, but should be supported */
         printf("%s  checking large %schunk not currently supported\n",
                verbose? ":":fname, verbose? "":"FRAM ");
         set_err(kMinorError);
@@ -3497,7 +3497,7 @@ FIXME: add support for decompressing/printing zTXt
                verbose? ":":fname, verbose? "":"FRAM ");
         set_err(kMinorError);
       } else if (sz > BS) {
-	/* FIXME: large SAVE chunks should be supported */
+        /* FIXME: large SAVE chunks should be supported */
         printf("%s  checking large %schunk not currently supported\n",
           verbose? ":":fname, verbose? "":"SAVE ");
         set_err(kMinorError);
@@ -3613,8 +3613,8 @@ FIXME: add support for decompressing/printing zTXt
           png? 'P':'J');
         set_err(kMinorError);
       } else if (sz > BS && verbose) {
-	/* FIXME: large nEED chunks are unusual, but should be supported */
-	printf(":  printing large chunk not currently supported\n");
+        /* FIXME: large nEED chunks are unusual, but should be supported */
+        printf(":  printing large chunk not currently supported\n");
       } else if (sz > 0 && verbose) {
         uch *p = buffer;
         uch *lastbreak = buffer;
@@ -3840,7 +3840,7 @@ FIXME: add support for decompressing/printing zTXt
           verbose? ":":fname, verbose? "":"LOOP ");
         set_err(kMajorError);
       } else if (sz > BS) {
-	/* FIXME: large LOOP chunks should be supported */
+        /* FIXME: large LOOP chunks should be supported */
         printf("%s  checking large %schunk not currently supported\n",
           verbose? ":":fname, verbose? "":"LOOP ");
         set_err(kMinorError);
@@ -4177,7 +4177,7 @@ FIXME: add support for decompressing/printing zTXt
           verbose? ":":fname, verbose? "":"PAST ");
         set_err(kMajorError);
       } else if (sz > BS) {
-	/* FIXME: large PAST chunks should be supported */
+        /* FIXME: large PAST chunks should be supported */
         printf("%s  checking large %schunk not currently supported\n",
                verbose? ":":fname, verbose? "":"PAST ");
         set_err(kMinorError);
@@ -4315,7 +4315,7 @@ FIXME: add support for decompressing/printing zTXt
           verbose? ":":fname, verbose? "":"DISC ");
         set_err(kMajorError);
       } else if (sz > BS) {
-	/* FIXME: large DISC chunks should be supported */
+        /* FIXME: large DISC chunks should be supported */
         printf("%s  checking large %schunk not currently supported\n",
                verbose? ":":fname, verbose? "":"DISC ");
         set_err(kMinorError);
@@ -4395,7 +4395,7 @@ FIXME: add support for decompressing/printing zTXt
           verbose? ":":fname, verbose? "":"DROP ");
         set_err(kMajorError);
       } else if (sz > BS) {
-	/* FIXME: large DROP chunks should be supported */
+        /* FIXME: large DROP chunks should be supported */
         printf("%s  checking large %schunk not currently supported\n",
                verbose? ":":fname, verbose? "":"DROP ");
         set_err(kMinorError);
@@ -4450,7 +4450,7 @@ FIXME: add support for decompressing/printing zTXt
         set_err(kMinorError);
       }
       if (sz > BS) {
-	/* FIXME: large DBYK chunks should be supported */
+        /* FIXME: large DBYK chunks should be supported */
         printf("%s  checking large %schunk not currently supported\n",
                verbose? ":":fname, verbose? "":"DBYK ");
         set_err(kMinorError);
@@ -4515,7 +4515,7 @@ FIXME: add support for decompressing/printing zTXt
         set_err(kMajorError);
       }
       if (sz > BS) {
-	/* FIXME: large ORDR chunks should be supported */
+        /* FIXME: large ORDR chunks should be supported */
         printf("%s  checking large %schunk not currently supported\n",
                verbose? ":":fname, verbose? "":"ORDR ");
         set_err(kMinorError);

--- a/pngcheck.c
+++ b/pngcheck.c
@@ -1037,7 +1037,7 @@ int pngcheck(FILE *fp, const char *fname, int searching, FILE *fpOut)
   bool have_iCCP = false, have_oFFs = false, have_pCAL = false, have_pHYs = false, have_sBIT = false;
   bool have_sCAL = false, have_sRGB = false, have_sTER = false, have_tIME = false, have_tRNS = false;
   bool have_SAVE = false, have_TERM = false, have_MAGN = false, have_pHYg = false;
-  int top_level = 1;
+  bool top_level = true;
   ulg zhead = 1;   /* 0x10000 indicates both zlib header bytes read */
   ulg crc, filecrc;
   ulg layers = 0L, frames = 0L;
@@ -1047,10 +1047,10 @@ int pngcheck(FILE *fp, const char *fname, int searching, FILE *fpOut)
   int vlc = -1, lc = -1;
   int bitdepth = 0, sampledepth = 0, ityp = 1, jtyp = 0, lace = 0, nplte = 0;
   int jbitd = 0, alphadepth = 0;
-  int did_stat = 0;
+  bool did_stat = false;
   printbuf_state prbuf_state;
   struct stat statbuf;
-  static int first_file = 1;
+  static bool first_file = true;
   const char *brief_warn  = color? brief_warn_color  : brief_warn_plain;
   const char *brief_OK    = color? brief_OK_color    : brief_OK_plain;
   const char *warnings_detected  = color? warnings_color : warnings_plain;
@@ -1066,13 +1066,13 @@ int pngcheck(FILE *fp, const char *fname, int searching, FILE *fpOut)
       printf("\n");
     } else {
       stat(fname, &statbuf);   /* know file exists => know stat() successful */
-      did_stat = 1;
+      did_stat = true;
       /* typecast long since off_t may be 64-bit (e.g., IRIX): */
       printf(" (%ld bytes)\n", (long)statbuf.st_size);
     }
   }
 
-  first_file = 0;
+  first_file = false;
   png = mng = jng = false;
 
   if (!searching) {
@@ -1314,7 +1314,7 @@ int pngcheck(FILE *fp, const char *fname, int searching, FILE *fpOut)
       }
       have_IHDR = true;
       if (mng)
-        top_level = 0;
+        top_level = false;
       last_is_IDAT = last_is_JDAT = false;
 #ifdef USE_ZLIB
       first_idat = 1;  /* flag:  next IDAT will be the first in this subimage */
@@ -1411,7 +1411,7 @@ int pngcheck(FILE *fp, const char *fname, int searching, FILE *fpOut)
       }
       have_JHDR = true;
       if (mng)
-        top_level = 0;
+        top_level = false;
       last_is_IDAT = last_is_JDAT = false;
 
     /*------*
@@ -3555,9 +3555,9 @@ FIXME: add support for decompressing/printing zTXt
             // name must match that in corresponding SEEK/FRAM/eXPI chunk, or
             // be omitted if unnamed segment (not checked!)
             if (bytes_left) {
-              int have_name = 0;
+              bool have_name = false;
               if (*p) {
-                have_name = 1;
+                have_name = true;
                 printf("    name = ");
               }
               do {
@@ -4459,7 +4459,7 @@ FIXME: add support for decompressing/printing zTXt
       } else if (no_err(kMinorError)) {
         uch *buf = buffer + 5;
         int bytes_left = sz - 5;
-        int first = 1;
+        bool first = true;
         int space_left = 75;
 
         if (verbose) {
@@ -4494,7 +4494,7 @@ FIXME: add support for decompressing/printing zTXt
             }
             printf("%s \"%.*s\"", sep, keylen, buf);
           }
-          first = 0;
+          first = false;
           buf += keylen+1;        /* no NULL separator for last keyword... */
           bytes_left -= keylen+1; /* ...but then bytes_left will be < 0:  NP */
         }

--- a/pngcheck.c
+++ b/pngcheck.c
@@ -182,26 +182,26 @@ typedef struct printbuf_state {
 void usage (FILE *fpMsg);
 #ifndef USE_ZLIB
 void make_crc_table (void);
-ulg  update_crc (ulg crc, uch *buf, int len);
+ulg  update_crc (ulg crc, const uch *buf, int len);
 #endif
 ulg  getlong (FILE *fp, const char *fname, const char *where);
 void putlong (FILE *fpOut, ulg ul);
 void init_printbuf_state (printbuf_state *prbuf);
-void print_buffer (printbuf_state *prbuf, uch *buffer, int size, int indent);
-void report_printbuf (printbuf_state *prbuf, const char *fname, const char *chunkid);
-int  keywordlen (uch *buffer, int maxsize);
+void print_buffer (printbuf_state *prbuf, const uch *buffer, int size, int indent);
+void report_printbuf (const printbuf_state *prbuf, const char *fname, const char *chunkid);
+int  keywordlen (const uch *buffer, int maxsize);
 const char *getmonth (int m);
 int  ratio (ulg uc, ulg c);
 ulg  gcf (ulg a, ulg b);
 int  pngcheck (FILE *fp, const char *_fname, int searching, FILE *fpOut);
 int  pnginfile (FILE *fp, const char *fname, int ipng, int extracting);
 void pngsearch (FILE *fp, const char *fname, int extracting);
-int  check_magic (uch *magic, const char *fname, int which);
+int  check_magic (const uch *magic, const char *fname, int which);
 int  check_chunk_name (const char *chunk_name, const char *fname);
-int  check_keyword (uch *buffer, int maxsize, int *pKeylen,
+int  check_keyword (const uch *buffer, int maxsize, int *pKeylen,
                     const char *keyword_name, const char *chunkid, const char *fname);
-int  check_text (uch *buffer, int maxsize, const char *chunkid, const char *fname);
-int  check_ascii_float (uch *buffer, int len, const char *chunkid, const char *fname);
+int  check_text (const uch *buffer, int maxsize, const char *chunkid, const char *fname);
+int  check_ascii_float (const uch *buffer, int len, const char *chunkid, const char *fname);
 char const * u2name_helper(unsigned int value, const char **names,
                            size_t nnames);
 
@@ -816,10 +816,10 @@ void make_crc_table(void)
    initialized to all 1's, and the transmitted value is the 1's complement
    of the final running crc. */
 
-ulg update_crc(ulg crc, uch *buf, int len)
+ulg update_crc(ulg crc, const uch *buf, int len)
 {
   ulg c = crc;
-  uch *p = buf;
+  const uch *p = buf;
   int n = len;
 
   if (!crc_table_computed) {
@@ -885,7 +885,7 @@ void init_printbuf_state(printbuf_state *prbuf)
 
 
 /* GRR EBCDIC WARNING */
-void print_buffer(printbuf_state *prbuf, uch *buf, int size, int indent)
+void print_buffer(printbuf_state *prbuf, const uch *buf, int size, int indent)
 {
   if (size < 1)
     return;
@@ -925,7 +925,7 @@ void print_buffer(printbuf_state *prbuf, uch *buf, int size, int indent)
 
 
 
-void report_printbuf(printbuf_state *prbuf, const char *fname, const char *chunkid)
+void report_printbuf(const printbuf_state *prbuf, const char *fname, const char *chunkid)
 {
   if (prbuf->cr) {
     if (prbuf->lf) {
@@ -951,7 +951,7 @@ void report_printbuf(printbuf_state *prbuf, const char *fname, const char *chunk
 
 
 
-int keywordlen(uch *buf, int maxsize)
+int keywordlen(const uch *buf, int maxsize)
 {
   int j = 0;
 
@@ -4961,7 +4961,7 @@ void pngsearch(FILE *fp, const char *fname, int extracting)
  * without any restrictions.
  *
  */
-int check_magic(uch *magic, const char *fname, int which)
+int check_magic(const uch *magic, const char *fname, int which)
 {
   int i;
   const uch *good_magic = (which == 0)? good_PNG_magic :
@@ -5043,7 +5043,7 @@ int check_chunk_name(const char *chunk_name, const char *fname)
 /* caller must do set_err(kMinorError) based on return value (0 == OK) */
 /* keyword_name is "keyword" for most chunks, but it can instead be "name" or
  * "identifier" or whatever makes sense for the chunk in question */
-int check_keyword(uch *buffer, int maxsize, int *pKeylen,
+int check_keyword(const uch *buffer, int maxsize, int *pKeylen,
                   const char *keyword_name, const char *chunkid, const char *fname)
 {
   int j, prev_space = 0;
@@ -5104,7 +5104,7 @@ int check_keyword(uch *buffer, int maxsize, int *pKeylen,
 
 /* GRR 20070707 */
 /* caller must do set_err(kMinorError) based on return value (0 == OK) */
-int check_text(uch *buffer, int maxsize, const char *chunkid, const char *fname)
+int check_text(const uch *buffer, int maxsize, const char *chunkid, const char *fname)
 {
   int j, ctrlwarn = verbose? 1 : 0;  /* print message once, only if verbose */
 
@@ -5127,9 +5127,9 @@ int check_text(uch *buffer, int maxsize, const char *chunkid, const char *fname)
 
 /* GRR 20061203 (used only for sCAL) */
 /* caller must do set_err(kMinorError) based on return value (0 == OK) */
-int check_ascii_float(uch *buffer, int len, const char *chunkid, const char *fname)
+int check_ascii_float(const uch *buffer, int len, const char *chunkid, const char *fname)
 {
-  uch *qq = buffer, *bufEnd = buffer + len;
+  const uch *qq = buffer, *bufEnd = buffer + len;
   int /* have_sign = 0, */ have_integer = 0, have_dot = 0, have_fraction = 0;
   int have_E = 0, have_Esign = 0, have_exponent = 0, in_digits = 0;
   int have_nonzero = 0;

--- a/pngcheck.c
+++ b/pngcheck.c
@@ -311,17 +311,10 @@ bool is_latin1_keyword_forbidden(uch x) {
   return (0x00 <= x && x <= 0x1F) || (0x7F <= x && x <= 0xA0);
 }
 
-/* GRR 20070707:  list of discouraged (control) characters in tEXt/zTXt text */
-static const uch latin1_text_discouraged[256] = {
-  1,1,1,1,1,1,1,1,1,1,0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
-  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,
-  1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
-  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0 
-};
+/* list of discouraged (control) characters in tEXt/zTXt text */
+bool is_latin1_text_discouraged(uch x) {
+  return (0x00 <= x && x <= 0x09) || (0x0B <= x && x <= 0x1F) || (0x7F <= x && x <= 0x9F);
+}
 
 #ifdef USE_ZLIB
    int first_idat = 1;           /* flag:  is this the first IDAT chunk? */
@@ -5120,7 +5113,7 @@ int check_text(const uch *buffer, int maxsize, const char *chunkid, const char *
       printf("%s  %s text contains NULL character(s)\n",
         verbose? ":":fname, verbose? "":chunkid);
       return 1;
-    } else if (ctrlwarn && latin1_text_discouraged[buffer[j]]) {
+    } else if (ctrlwarn && is_latin1_text_discouraged(buffer[j])) {
       printf(":   text has control character(s) (%u) (discouraged)\n",
         buffer[j]);
       ctrlwarn = false;

--- a/pngcheck.c
+++ b/pngcheck.c
@@ -249,7 +249,7 @@ char const * u2name_helper(unsigned int value, const char **names,
 #define is_err(x)   (global_error >= (x))
 #define no_err(x)   (global_error < (x))
 
-enum {
+enum Error {
   kOK = 0,
   kWarning,           /* could be an error in some circumstances but not all */
   kCommandLineError,  /* pilot error */
@@ -273,7 +273,7 @@ int png = 0;		/* it's a PNG */
 int mng = 0;		/* it's a MNG instead of a PNG (won't work in pipe) */
 int jng = 0;		/* it's a JNG */
 
-int global_error = kOK; /* the current error status */
+enum Error global_error = kOK; /* the current error status */
 uch buffer[BS];
 
 /* what the PNG, MNG and JNG magic numbers should be */
@@ -562,7 +562,7 @@ int main(int argc, char *argv[])
 {
   FILE *fp;
   int i = 1;
-  int err = kOK;
+  enum Error err = kOK;
   int num_files = 0;
   int num_errors = 0;
   int num_warnings = 0;
@@ -4862,7 +4862,7 @@ FIXME: add support for decompressing/printing zTXt
 int pnginfile(FILE *fp, const char *fname, int ipng, int extracting)
 {
   char name[1024], *szdot;
-  int err = kOK;
+  enum Error err = kOK;
   FILE *fpOut = NULL;
 
 #if 1

--- a/pngcheck.c
+++ b/pngcheck.c
@@ -1031,7 +1031,8 @@ int pngcheck(FILE *fp, const char *fname, int searching, FILE *fpOut)
   bool have_MHDR = false, have_MEND = false;
   bool /* have_DHDR = false, */ have_PLTE = false;
   bool have_JHDR = false, have_JSEP = false, need_JSEP = false;
-  int have_IDAT = 0, have_JDAT = 0, last_is_IDAT = 0, last_is_JDAT = 0;
+  int have_IDAT = 0, have_JDAT = 0;
+  bool last_is_IDAT = false, last_is_JDAT = false;
   bool have_bKGD = false, have_cHRM = false, have_eXIf = false, have_gAMA = false, have_hIST = false;
   bool have_iCCP = false, have_oFFs = false, have_pCAL = false, have_pHYs = false, have_sBIT = false;
   bool have_sCAL = false, have_sRGB = false, have_sTER = false, have_tIME = false, have_tRNS = false;
@@ -1314,7 +1315,7 @@ int pngcheck(FILE *fp, const char *fname, int searching, FILE *fpOut)
       have_IHDR = true;
       if (mng)
         top_level = 0;
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 #ifdef USE_ZLIB
       first_idat = 1;  /* flag:  next IDAT will be the first in this subimage */
       zlib_error = 0;  /* flag:  no zlib errors yet in this file */
@@ -1411,7 +1412,7 @@ int pngcheck(FILE *fp, const char *fname, int searching, FILE *fpOut)
       have_JHDR = true;
       if (mng)
         top_level = 0;
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 
     /*------*
      | MHDR |
@@ -1570,7 +1571,7 @@ FIXME: make sure bit 31 (0x80000000) is 0
         }
       }
       have_MHDR = true;
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 
     /*================================================*
      * PNG chunks (with the exception of IHDR, above) *
@@ -1640,7 +1641,7 @@ FIXME: make sure bit 31 (0x80000000) is 0
         }
       }
       have_PLTE = true;
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 
     /*------*
      | IDAT |
@@ -1988,8 +1989,8 @@ FIXME: make sure bit 31 (0x80000000) is 0
       if (zlib_error > 0)  /* our flag, not zlib's (-1 means normal exit) */
         set_err(kMajorError);
 #endif /* USE_ZLIB */
-      last_is_IDAT = 1;
-      last_is_JDAT = 0;
+      last_is_IDAT = true;
+      last_is_JDAT = false;
 
     /*------*
      | IEND |
@@ -2024,7 +2025,7 @@ FIXME: make sure bit 31 (0x80000000) is 0
         printf("\n");
       }
       have_IEND = true;
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 
     /*------*
      | bKGD |
@@ -2079,7 +2080,7 @@ FIXME: make sure bit 31 (0x80000000) is 0
           break;
       }
       have_bKGD = true;
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 
     /*------*
      | cHRM |
@@ -2142,7 +2143,7 @@ FIXME: make sure bit 31 (0x80000000) is 0
         }
       }
       have_cHRM = true;
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 
     /*------*
      | eXIf |
@@ -2166,7 +2167,7 @@ FIXME: make sure bit 31 (0x80000000) is 0
         }
       }
       have_eXIf = true;
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 
     /*------*
      | fRAc |
@@ -2175,7 +2176,7 @@ FIXME: make sure bit 31 (0x80000000) is 0
       if (verbose)
         printf("\n    undefined fractal parameters (ancillary, safe to copy)\n"
           "    [contact Tim Wegner, twegner@phoenix.net, for specification]\n");
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 
     /*------*
      | gAMA |
@@ -2210,7 +2211,7 @@ FIXME: make sure bit 31 (0x80000000) is 0
         printf(": %#0.5g\n", (double)LG(buffer)/100000);
       }
       have_gAMA = true;
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 
     /*------*
      | gIFg |
@@ -2230,7 +2231,7 @@ FIXME: make sure bit 31 (0x80000000) is 0
         printf("\n    disposal method = %d, user input flag = %d, display time = %lf seconds\n",
           buffer[0], buffer[1], dtime);
       }
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 
     /*------*
      | gIFt |
@@ -2257,7 +2258,7 @@ FIXME: make sure bit 31 (0x80000000) is 0
         printf("    %ld bytes of text data\n", sz-24);
         /* GRR:  print text according to grid size/cell size? */
       }
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 
     /*------*
      | gIFx |
@@ -2277,7 +2278,7 @@ FIXME: make sure bit 31 (0x80000000) is 0
           8, buffer, buffer[8], buffer[9], buffer[10]);
         printf("    %ld bytes of application data\n", sz-11);
       }
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 
     /*------*
      | hIST |
@@ -2324,7 +2325,7 @@ FIXME: make sure bit 31 (0x80000000) is 0
           printf("%s%3d:  %5u\n", spc, i, SH(buffer+j));
       }
       have_hIST = true;
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 
     /*------*
      | iCCP |
@@ -2382,7 +2383,7 @@ FIXME: make sure bit 31 (0x80000000) is 0
         }
       }
       have_iCCP = true;
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 
     /*------*
      | iTXt |
@@ -2448,7 +2449,7 @@ FIXME: make sure bit 31 (0x80000000) is 0
         }
         report_printbuf(&prbuf_state, fname, chunkid);   /* print CR/LF & NULLs info */
       }
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 
     /*------*
      | oFFs |
@@ -2475,7 +2476,7 @@ FIXME: make sure bit 31 (0x80000000) is 0
                (buffer[8] == 0)? "pixels":"micrometers");
       }
       have_oFFs = true;
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 
     /*------*
      | pCAL |
@@ -2579,7 +2580,7 @@ FIXME: make sure bit 31 (0x80000000) is 0
         }
       }
       have_pCAL = true;
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 
     /*------*
      | pHYs |
@@ -2617,7 +2618,7 @@ FIXME: make sure bit 31 (0x80000000) is 0
         printf("\n");
       }
       have_pHYs = true;
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 
     /*------*
      | sBIT |
@@ -2725,7 +2726,7 @@ FIXME: make sure bit 31 (0x80000000) is 0
           break;
       }
       have_sBIT = true;
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 
     /*------*
      | sCAL |
@@ -2808,7 +2809,7 @@ FIXME: make sure bit 31 (0x80000000) is 0
                (unittype == 1)? "meters":"radians");
       }
       have_sCAL = true;
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 
     /*------*
      | sPLT |
@@ -2900,7 +2901,7 @@ FIXME: make sure bit 31 (0x80000000) is 0
           }
         }
       }
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 
     /*------*
      | sRGB |
@@ -2935,7 +2936,7 @@ FIXME: make sure bit 31 (0x80000000) is 0
                U2NAME(buffer[0], rendering_intent));
       }
       have_sRGB = true;
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 
     /*------*
      | sTER |
@@ -2962,7 +2963,7 @@ FIXME: make sure bit 31 (0x80000000) is 0
                buffer[0]? "divergent (parallel)":"cross-eyed");
       }
       have_sTER = true;
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 
     /*------*  *------*
      | tEXt |  | zTXt |
@@ -3023,7 +3024,7 @@ FIXME: add support for decompressing/printing zTXt
         }
         report_printbuf(&prbuf_state, fname, chunkid);
       }
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 
     /*------*
      | tIME |
@@ -3080,7 +3081,7 @@ FIXME: add support for decompressing/printing zTXt
         }
       }
       have_tIME = true;
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 
     /*------*
      | tRNS |
@@ -3157,7 +3158,7 @@ FIXME: add support for decompressing/printing zTXt
         }
       }
       have_tRNS = true;
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 
     /*===========================================*/
     /* identifiable private chunks; guts unknown */
@@ -3169,7 +3170,7 @@ FIXME: add support for decompressing/printing zTXt
       if (verbose)
         printf("\n    "
           "Microsoft Picture It private, ancillary, unsafe-to-copy chunk\n");
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 
     /*------*
      | cmPP |   (guessing MS)
@@ -3178,7 +3179,7 @@ FIXME: add support for decompressing/printing zTXt
       if (verbose)
         printf("\n    "
           "Microsoft Picture It(?) private, ancillary, unsafe-to-copy chunk\n");
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 
     /*------*
      | cpIp |
@@ -3187,7 +3188,7 @@ FIXME: add support for decompressing/printing zTXt
       if (verbose)
         printf("\n    "
           "Microsoft Picture It private, ancillary, safe-to-copy chunk\n");
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 
     /*------*
      | mkBF |
@@ -3196,7 +3197,7 @@ FIXME: add support for decompressing/printing zTXt
       if (verbose)
         printf("\n    "
           "Macromedia Fireworks private, ancillary, unsafe-to-copy chunk\n");
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 
     /*------*
      | mkBS |
@@ -3205,7 +3206,7 @@ FIXME: add support for decompressing/printing zTXt
       if (verbose)
         printf("\n    "
           "Macromedia Fireworks private, ancillary, unsafe-to-copy chunk\n");
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 
     /*------*
      | mkBT |
@@ -3214,7 +3215,7 @@ FIXME: add support for decompressing/printing zTXt
       if (verbose)
         printf("\n    "
           "Macromedia Fireworks private, ancillary, unsafe-to-copy chunk\n");
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 
     /*------*
      | mkTS |
@@ -3223,7 +3224,7 @@ FIXME: add support for decompressing/printing zTXt
       if (verbose)
         printf("\n    "
           "Macromedia Fireworks(?) private, ancillary, unsafe-to-copy chunk\n");
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 
     /* msOG - Microsoft?  Macromedia? */
 
@@ -3234,7 +3235,7 @@ FIXME: add support for decompressing/printing zTXt
       if (verbose)
         printf("\n    "
           "Piclab(?) private, ancillary, safe-to-copy chunk\n");
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 
     /*------*
      | prVW |
@@ -3243,7 +3244,7 @@ FIXME: add support for decompressing/printing zTXt
       if (verbose)
         printf("\n    Macromedia Fireworks preview chunk"
           " (private, ancillary, unsafe to copy)\n");
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 
     /*------*
      | spAL |  intermediate sPLT test version (still had gamma field)
@@ -3253,7 +3254,7 @@ FIXME: add support for decompressing/printing zTXt
       if (verbose)
         printf("\n    preliminary/test version of sPLT "
           "(private, ancillary, unsafe to copy)\n");
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 
     /*================================================*
      * JNG chunks (with the exception of JHDR, above) *
@@ -3282,8 +3283,8 @@ FIXME: add support for decompressing/printing zTXt
       } else if (verbose)
         printf("\n");
       have_JDAT = 1;
-      last_is_IDAT = 0;
-      last_is_JDAT = 1;   /* also true if last was JSEP (see below) */
+      last_is_IDAT = false;
+      last_is_JDAT = true;   /* also true if last was JSEP (see below) */
 
     /*------*
      | JSEP |
@@ -3311,8 +3312,8 @@ FIXME: add support for decompressing/printing zTXt
         printf("\n");
       }
       have_JSEP = true;
-      last_is_IDAT = 0;
-      last_is_JDAT = 1;   /* effectively... (GRR HACK) */
+      last_is_IDAT = false;
+      last_is_JDAT = true;   /* effectively... (GRR HACK) */
 
     /*===============================================================*
      * MNG chunks (with the exception of MHDR and JNG chunks, above) *
@@ -3358,7 +3359,7 @@ FIXME: add support for decompressing/printing zTXt
         }
       }
       //have_DHDR = true;
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 #ifdef USE_ZLIB
       first_idat = 1;  /* flag:  next IDAT will be the first in this subimage */
       zlib_error = 0;  /* flag:  no zlib errors yet in this file */
@@ -3480,7 +3481,7 @@ FIXME: add support for decompressing/printing zTXt
  */
         }
       }
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 
     /*------*
      | SAVE |
@@ -3577,7 +3578,7 @@ FIXME: add support for decompressing/printing zTXt
         printf("\n");
       }
       have_SAVE = true;
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 
     /*------*
      | SEEK |
@@ -3603,7 +3604,7 @@ FIXME: add support for decompressing/printing zTXt
           printf("\n");
         }
       }
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 
     /*------*
      | nEED |
@@ -3636,7 +3637,7 @@ FIXME: add support for decompressing/printing zTXt
         } while (++p < buffer + sz);
         printf("\n");
       }
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 
     /*------*
      | DEFI |
@@ -3677,7 +3678,7 @@ FIXME: add support for decompressing/printing zTXt
             LG(buffer+12), LG(buffer+16), LG(buffer+20), LG(buffer+24));
         }
       }
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 
     /*------*
      | BACK |
@@ -3702,7 +3703,7 @@ FIXME: add support for decompressing/printing zTXt
             (sz > 9 && (buffer[9] & 1))? "":"do not ");
         }
       }
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 
     /*------*
      | MOVE |
@@ -3728,7 +3729,7 @@ FIXME: add support for decompressing/printing zTXt
           printf("    new position:  x = %ld, y = %ld\n",
             LG(buffer+5), LG(buffer+9));
       }
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 
     /*------*
      | CLON |
@@ -3773,7 +3774,7 @@ FIXME: add support for decompressing/printing zTXt
         else
           printf("    absolute position:  x = %ld, y = %ld\n", x, y);
       }
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 
     /*------*
      | SHOW |
@@ -3804,7 +3805,7 @@ FIXME: add support for decompressing/printing zTXt
         printf("\n    first object = %u, last object = %u\n", first, last);
         printf("    %s\n", U2NAME(smode, show_mode));
       }
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 
     /*------*
      | CLIP |
@@ -3826,7 +3827,7 @@ FIXME: add support for decompressing/printing zTXt
         printf("      left = %ld, right = %ld, top = %ld, bottom = %ld\n",
           LG(buffer+5), LG(buffer+9), LG(buffer+13), LG(buffer+17));
       }
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 
     /*------*
      | LOOP |
@@ -3867,7 +3868,7 @@ FIXME: add support for decompressing/printing zTXt
           printf("\n");
         }
       }
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 
     /*------*
      | ENDL |
@@ -3884,7 +3885,7 @@ FIXME: add support for decompressing/printing zTXt
       }
       if (verbose && no_err(kMinorError))
         printf(":  nest level = %u\n", (unsigned)(buffer[0]));
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 
     /*------*
      | PROM |
@@ -3924,7 +3925,7 @@ FIXME: add support for decompressing/printing zTXt
           buffer[2]? "zero fill" : "left bit replication");
           /* GRR:  not checking for valid buffer[2] values */
       }
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 
     /*------*
      | fPRI |
@@ -3942,7 +3943,7 @@ FIXME: add support for decompressing/printing zTXt
       if (verbose && no_err(kMinorError))
         printf(":  %spriority = %u\n", buffer[0]? "delta " : "",
           (unsigned)(buffer[1]));
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 
     /*------*
      | eXPI |
@@ -3961,7 +3962,7 @@ FIXME: add support for decompressing/printing zTXt
         printf("\n    snapshot ID = %u, snapshot name = %.*s\n", SH(buffer),
           (int)(sz-2), buffer+2);	/* GRR EBCDIC WARNING */
       }
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 
     /*------*
      | BASI |
@@ -4061,7 +4062,7 @@ FIXME: add support for decompressing/printing zTXt
           }
         }
       }
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 
     /*------*
      | IPNG |    (empty stand-in for IHDR)
@@ -4078,7 +4079,7 @@ FIXME: add support for decompressing/printing zTXt
       } else if (verbose) {
         printf("\n");
       }
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 
     /*------*
      | PPLT |
@@ -4163,7 +4164,7 @@ FIXME: add support for decompressing/printing zTXt
             npplt, (dtype & 1)? "delta" : "replacement", npplt== 1? "y":"ies",
             nblks, nblks== 1? "":"s");
       }
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 
     /*------*
      | PAST |
@@ -4254,7 +4255,7 @@ FIXME: add support for decompressing/printing zTXt
           bytes_left -= 30;
         }
       }
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 
     /*------*
      | TERM |
@@ -4301,7 +4302,7 @@ FIXME: add support for decompressing/printing zTXt
         }
       }
       have_TERM = true;
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 
     /*------*
      | DISC |
@@ -4337,7 +4338,7 @@ FIXME: add support for decompressing/printing zTXt
           }
         }
       }
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 
     /*------*
      | pHYg |
@@ -4381,7 +4382,7 @@ FIXME: add support for decompressing/printing zTXt
         }
       }
       have_pHYg = true;
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 
     /*------*
      | DROP |
@@ -4422,7 +4423,7 @@ FIXME: add support for decompressing/printing zTXt
         if (verbose)
           printf("\n");
       }
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 
     /*------*
      | DBYK |
@@ -4500,7 +4501,7 @@ FIXME: add support for decompressing/printing zTXt
         if (verbose)
           printf("\n");
       }
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 
     /*------*
      | ORDR |
@@ -4548,7 +4549,7 @@ FIXME: add support for decompressing/printing zTXt
           bytes_left -= 5;
         }
       }
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 
     /*------*
      | MAGN |
@@ -4630,7 +4631,7 @@ FIXME: add support for decompressing/printing zTXt
         }
       }
       have_MAGN = true;
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 
     /*------*
      | MEND |
@@ -4651,7 +4652,7 @@ FIXME: add support for decompressing/printing zTXt
         printf("\n");
       }
       have_MEND = true;
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
 
     /*===============*
      * unknown chunk *
@@ -4692,7 +4693,7 @@ FIXME: add support for decompressing/printing zTXt
                RESERVED(chunkid)  ? "reserved-bit-set, ":"",
                SAFECOPY(chunkid)  ? "":"un");
       }
-      last_is_IDAT = last_is_JDAT = 0;
+      last_is_IDAT = last_is_JDAT = false;
     }
 
     /*=======================================================================*/

--- a/pngcheck.c
+++ b/pngcheck.c
@@ -999,17 +999,12 @@ int ratio(ulg uc, ulg c)   /* GRR 19970621:  swiped from UnZip 5.31 list.c */
  */
 ulg gcf(ulg a, ulg b)
 {
-    ulg r;
-
-    if (b == 0)
-      return (a == 0)? 1 : a;
-
-    while ((r = a - (a/b)*b) != 0) {
-      a = b;
-      b = r;
-    }
-
-    return b;
+  while (b != 0) {
+    ulg c = a % b;
+    a = b;
+    b = c;
+  }
+  return (a != 0)? a : 1;
 }
 
 


### PR DESCRIPTION
I apologize for the complexity of processing this set of commits.

Back on 2021-09-12, after emailing Greg Roelofs, I imported the publicly available source code of pngcheck at version 3.0.3 (released on 2021-04-25). Evidently, other people have imported that code and ended up with the exact same working tree but with different commit metadata: [a9cf3731 by Nayuki](https://github.com/nayuki/pngcheck/tree/a9cf37311e66fe5536abc85694c94497ac0dd2df), [cab5ffb1 by svgeesus](https://github.com/pnggroup/pngcheck/tree/cab5ffb14756974e9e04ff432a1a742fd8d95971), [67d38027 by Chris Lilley](https://github.com/pnggroup/pngcheck/tree/67d380279503e6a34f365a8219d15f4815bb1efe). You can confirm the matches by performing `git diff <CommitHash0> <CommitHash1>` and seeing zero output.

From that initial state, I made 21 changes, and I'll let the commit messages speak for themselves (oldest to newest):

0. Added authorship information.
0. Fixed indentation to eliminate tabs and consistently use 2 spaces.
0. Changed function signatures to take const char pointers for safety.
0. Changed function signatures to take const pointers when possible for safety.
0. Gave name to an anonymous enum, changed variable types to match.
0. Converted struct printbuf_state to use bool members instead of int.
0. Converted command-line flag global variables to be bool instead of int.
0. Converted pngcheck()'s have_<chunk> variables to be bool instead of int.
0. Converted pngcheck()'s last_is_IDAT and last_is_JDAT variables to be bool instead of int.
0. Converted pngcheck()'s miscellaneous variables to be bool instead of int.
0. Converted check_ascii_float()'s relevant variables to be bool instead of int.
0. Converted miscellaneous variables to be bool instead of int.
0. Converted two functions' parameters to be bool instead of int.
0. Converted chunk type bit-testing macros to functions for safety.
0. Reordered declarations pertaining to global error status.
0. Converted global-error macros to functions for safety.
0. Converted isASCIIalpha() from macro to a renamed function, tweaked parameter type and declaration ordering.
0. Replaced latin1_keyword_forbidden table with a renamed function.
0. Replaced latin1_text_discouraged table with a renamed function.
0. Added no-op casts to clarify signed-unsigned comparisons and suppress compiler warnings.
0. Simplified gcf() while producing identical results.

The result of my original batch of work is at https://github.com/nayuki/pngcheck/tree/ea8192e360e6b13b6699908b2f5198395a24ca21 . The changes amount to improvements for human readability and semantic clarity, but don't introduce any new functionality. I confirm that the code compiles with no errors in GCC and LLVM.

I just discovered this project repository ( https://github.com/pnggroup/pngcheck ) today and it looks official enough that it could host the work that I did. To that end, I rebased my commits so that the starting point is not a9cf3731 but instead cab5ffb1 (which as I said before, has the exact same working tree). The new tip of my development branch is [e2cfeeb0 (patch-0)](https://github.com/nayuki/pngcheck/tree/e2cfeeb028cedb620fe5d27ba002a907750cfcc3), and is what I am proposing in this pull request.

I understand that this has merge conflicts with the [current main commit](https://github.com/pnggroup/pngcheck/tree/7d059c5c9d9eff8741ca9f163b2513e79e2512d4) and probably doesn't have a simple resolution. I understand that while each of my commits is simple and self-contained, the cumulative result of all of them is not easy for you to handle.

Let me know if this work is acceptable, and whether I can do anything to help get it integrated. Thank you for your consideration.