### PR TITLE
Release 4.0.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@
  *   AED  -  Andreas Dilger
  *   BB   -  Ben Beasley (Fedora Linux)
  *   CL   -  Chris Lilley
+ *   CT   -  Cosmin Truta
  *   GRP  -  Glenn Randers-Pehrson
  *   GRR  -  Greg Roelofs
  *   JB   -  John Bowler
@@ -269,4 +270,15 @@
  * 20250115 CL:  Add mDCV support. Add cLLI support
  * 20250116 CL:  Fix narrow-range bug
  * 20250123 CL:  Detect eXIf after IDAT for PNG Third Edition compliance
+ * 20250124 CL:  Added APNG support
+ * 20250203 CL:  Test for fdAT after each fcTL (except first)
+ * 20250204 CL:  Either IDAT or fdAT needed after fcTL
+ * 20250207 CL:  Fix (almost) all warnings about signed vs unsigned comparisons
+ * 20250218 CL:  Detect unknown (zero) in cLLI
+ * 20250218 CT:  Merge git history (to 3.0.3) and unofficial fork
+ * 20250221 JB:  CLEANUP: Add warnings, add const to char *
+ * 20250303 CL:  Add P3D65-PQ to known cICP color spaces
+ * 20250303 CL:  released version 4.0.0
+ *               ----------------------
+
  

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
-# pngcheck unofficial of 03 Feb 2025
+# pngcheck 4.0.0
 
-pngcheck is a command-line utility to check PNG image files for validity 
+pngcheck is a command-line utility to check PNG image files,
+including animated PNG, for validity
 and to give information about metadate inside the file
 (apart from the actual image data).
 
-This unofficial version is forked from pngcheck 3.0.3
-(see [3.0.3 README](./README-303)) and adds the following new 
-features:
+This version was derived from pngcheck 3.0.3
+(see [3.0.3 README](./README-303)) and adds the following new
+features from [PNG Third Edition](https://w3c.github.io/png/):
 
 - Coding Independent Code Points [`cICP`](https://w3c.github.io/png/#cICP-chunk)
 - Mastering Display Color Volume [`mDCV`](https://w3c.github.io/png/#mDCV-chunk)

--- a/pngcheck.1
+++ b/pngcheck.1
@@ -1,6 +1,6 @@
-.TH PNGCHECK "1" "April 2021" "pngcheck 3.0.3" "User Commands"
+.TH PNGCHECK "1" "March 2025" "pngcheck 4.0.0" "User Commands"
 .SH NAME
-pngcheck \- manual page for pngcheck 3.0.3
+pngcheck \- manual page for pngcheck 4.0.0
 .SH SYNOPSIS
 .B pngcheck
 .RI [ \-7cpqtv ]
@@ -13,8 +13,8 @@ pngcheck \- manual page for pngcheck 3.0.3
 .B pngcheck
 .RI [ \-7cpqstvx ] \ file-containing-PNGs ...
 .SH DESCRIPTION
-PNGcheck, version 3.0.3 of 25 April 2021,
-by Alexander Lehmann, Andreas Dilger and Greg Roelofs.
+PNGcheck, version 4.0.0 of 3 March 2025,
+by Alexander Lehmann, Andreas Dilger, Greg Roelofs and Chris Lilley.
 .PP
 Test PNG, JNG or MNG image files for corruption, and print size/type info.
 .SH OPTIONS

--- a/pngcheck.c
+++ b/pngcheck.c
@@ -34,7 +34,7 @@
  *
  *===========================================================================*/
 
-#define VERSION "unofficial of 24 Jan 2025"
+#define VERSION "4.0.0"
 
 /*
  * NOTE:  current MNG support is informational; error-checking is MINIMAL!


### PR DESCRIPTION
@ctruta said:

> As I understand the SemVer rules, it should not be called 3.0.4. That would be the kind of SemVer breach that the present-day libpng is also guilty of. You should make it at least 3.1, or 3.1.0, or (if you wish to account for the rather significant new features) bump it all the way to 4.0.

This PR calls it 4.0.0 because indeed, significant new features

Very minimal man page update, hope I didn't break anything.

Also updated the changelog, up to release