### PR TITLE
a cICP chunk must accompany the use of mDCV

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -285,3 +285,5 @@
                  project; we're moving them to a new home
  * 20250307 CL:  test for tIME valid day in month
  * 20250328 CL:  Add cICP autodetect for BT.601 PAL, SECAM and NTSC
+ * 20250516 CL:  Add test for missing cICP, if mDCV is present
+

--- a/pngcheck.c
+++ b/pngcheck.c
@@ -5323,6 +5323,12 @@ FIXME: add support for decompressing/printing zTXt
       printf("%s  file doesn't end with a%sEND chunk\n", verbose? "":fname,
         mng? " M":"n I");
       set_err(kMinorError);
+    } else {
+      if (have_mDCV && !have_cICP) {
+        printf("%s  file has %smDCV%s, but does not have %scICP%s\n", verbose? "":fname,
+        color? COLOR_YELLOW:"", color? COLOR_NORMAL:"", color? COLOR_YELLOW:"", color? COLOR_NORMAL:"");
+      set_err(kMinorError);
+      }
     }
   }
 

--- a/pngcheck.c
+++ b/pngcheck.c
@@ -5327,7 +5327,7 @@ FIXME: add support for decompressing/printing zTXt
       if (have_mDCV && !have_cICP) {
         printf("%s  file has %smDCV%s, but does not have %scICP%s\n", verbose? "":fname,
         color? COLOR_YELLOW:"", color? COLOR_NORMAL:"", color? COLOR_YELLOW:"", color? COLOR_NORMAL:"");
-      set_err(kMinorError);
+        set_err(kMinorError);
       }
     }
   }


### PR DESCRIPTION
Adds a check for [PNG 3e `mDCV` statement](https://www.w3.org/TR/png-3/#mDCV-chunk):

> Since mDCV was originally created as supplemental static metadata meant to optimize the tone-mapping of images on a video display target, a cICP chunk must accompany the use of mDCV in order to establish the basic characteristics of the image content.

Check added after the immense while loop, since these chunks can occur in either order.