### PR TITLE
fix signedness comparison issue

### DIFF
--- a/pngcheck.c
+++ b/pngcheck.c
@@ -1960,12 +1960,12 @@ FIXME: make sure bit 31 (0x80000000) is 0
                   eod-p);		// ptrdiff_t
                 printf("\n     ");
                 fflush(stdout);
-                i = inflateEnd(&zstrm);	/* we're all done */
-                if (i == Z_OK || i == Z_STREAM_ERROR)
+				int r = inflateEnd(&zstrm);	/* we're all done */
+                if (r == Z_OK || r == Z_STREAM_ERROR)
                   printf(" inflateEnd() returns %s\n     ",
-                    i == Z_OK? "Z_OK" : "Z_STREAM_ERROR");
+                    r == Z_OK? "Z_OK" : "Z_STREAM_ERROR");
                 else
-                  printf(" inflateEnd() returns %d\n     ", i);
+                  printf(" inflateEnd() returns %d\n     ", r);
                 fflush(stdout);
               } else
                 inflateEnd(&zstrm);	/* we're all done */


### PR DESCRIPTION
Before this change, one gets the following warning on GCC 11.*:

	cc  -c  -I../zlib -DUSE_ZLIB -pedantic-errors  -Wall -Wextra -Wundef  -O2  -o pngcheck.o pngcheck.c
	pngcheck.c: In function ‘pngcheck’:
	pngcheck.c:1964:36: warning: comparison of integer expressions of different signedness: ‘unsigned int’ and ‘int’ [-Wsign-compare]
	 1964 |                 if (i == Z_OK || i == Z_STREAM_ERROR)
		  |                                    ^~

Z_STREAM_ERROR is defined to be (-2), hence the warning. cf. https://www.zlib.net/manual.html

Because of this v4.0.0 fails to compile out of the box on systems using recent GHCs as the former Makefile.unx has `-Werror` active.

This PR uses a different variable to store the result of `inflateEnd`.

Since v3.0.3, the variable `i` in main has been changed from signed to unsigned.  However, `inflateEnd` returns an `int` not an `unsigned int`, so reusing the `i` variable as the result doesn't seem proper.  This PR hopefully fixes the issue.