### PR TITLE
Automatic expansion of wildcard arguments -- an alternative solution

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,37 @@ if(NOT PNGCHECK_USE_SYSTEM_ZLIB)
   target_link_libraries(pngcheck PRIVATE zlibstatic)
 endif()
 
+# Compiler-specific options: enable commonly-used warning options
+if(CMAKE_C_COMPILER_ID MATCHES "(GNU|Clang)$")
+  set(CMAKE_C_FLAGS "-Wall -Wextra -Wundef ${CMAKE_C_FLAGS}")
+elseif(CMAKE_C_COMPILER_ID STREQUAL "MSVC")
+  set(CMAKE_C_FLAGS "/W3 ${CMAKE_C_FLAGS}")
+endif()
+
+# Compiler-specific options: disable function deprecation warnings on Windows
+if(WIN32 AND (CMAKE_C_COMPILER_ID MATCHES "MSVC|Intel|Clang"))
+  add_definitions(-D_CRT_NONSTDC_NO_DEPRECATE)
+  add_definitions(-D_CRT_SECURE_NO_DEPRECATE)
+endif()
+
+# Compiler-specific options: auto-expand the wildcard arguments on Windows
+if(WIN32 AND (CMAKE_C_COMPILER_ID STREQUAL "MSVC"))
+  # FIXME(clang):
+  # This should also work with Clang on Windows when using the MSVC runtime,
+  # but detection of the availability of setargv.obj is currently missing.
+  set(PNGCHECK_EXTRA_LINKER_FILES setargv.obj)
+elseif(WIN32 AND (CMAKE_C_COMPILER_ID MATCHES "(Borland|Embarcadero)$"))
+  if(CMAKE_C_COMPILER MATCHES "bcc64(\.exe)?$")
+    set(PNGCHECK_EXTRA_LINKER_FILES wildargs.o)
+  else()
+    set(PNGCHECK_EXTRA_LINKER_FILES wildargs.obj)
+  endif()
+endif()
+if(PNGCHECK_EXTRA_LINKER_FILES)
+  message(STATUS "Linking to ${PNGCHECK_EXTRA_LINKER_FILES}")
+  set(CMAKE_EXE_LINKER_FLAGS "${PNGCHECK_EXTRA_LINKER_FILES} ${CMAKE_EXE_LINKER_FLAGS}")
+endif()
+
 # Installation rules
 include(GNUInstallDirs)
 install(TARGETS pngcheck

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -110,14 +110,13 @@
 
 ## Notes
 
-- CMake build is recommended as it handles dependencies and platform
+- The CMake build is recommended, as it handles dependencies and platform
   differences automatically.
 - zlib support used to be optional, but now it is mandatory.
-- On Windows with MSVC, `setargv.obj` is included to handle file wildcards.
-- For MinGW/gcc and Cygwin/gcc on Windows, as well as EMX/gcc on OS/2,
-  wildcard argument handling is built-in.
-- For other non-Unix compilers such as Borland C or Watcom C, wildcard
-  argument handling is not currently supported.
+- The MSVC compiler on Windows provides `setargv.obj`, a module whose purpose
+  is to auto-expand the file wildcards in the command line at program startup.
+  Other compilers may provide similar modules, in C source form or in compiled
+  object code form; please consult your compiler's documentation.
 
 ## More Information
 

--- a/pngcheck.c
+++ b/pngcheck.c
@@ -82,7 +82,6 @@
  *       XXXX() function (e.g., IDAT(), tRNS())
  *   * print zTXt, compressed iTXt and iCCP chunks if -t option
  *       (break out zlib decoder into separate function and reuse)
- *   ? DOS/Win32 wildcard support beyond emx+gcc, MSVC (Borland wildargs.obj?)
  *   ? EBCDIC support (minimal?)
  *   - go back and make sure validation checks not dependent on verbosity level
  *
@@ -116,14 +115,15 @@
  *       [copy pngcheck.exe to the installation directory]
  *
  * "setargv.obj" is included with MSVC and will be found if the batch file has
- * been run.  Either Borland or Watcom (both?) may use "wildargs.obj" instead.
- * Both object files serve the same purpose:  they expand wildcard arguments
- * into a list of files on the local file system, just as Unix shells do by
- * default ("globbing").  Note that mingw32 + gcc (Unix-like compilation
- * environment for Windows) apparently expands wildcards on its own, so no
- * special object files are necessary for it.  emx + gcc for OS/2 (and possibly
- * rsxnt + gcc for Windows NT) has a special _wildcard() function call, which
- * is already included at the top of main() below.
+ * been run.  Similarly, Borland C has "wildargs.obj", while Watcom C has (in
+ * source code form) "wildargv.c".
+ * All these files serve the same purpose: they expand wildcard arguments into
+ * a list of files on the local file system, just as Unix shells do by default
+ * ("globbing").  Note that mingw32 + gcc (Unix-like compilation environment
+ * for Windows) apparently expands wildcards on its own, so no special object
+ * files are necessary for it.  emx + gcc for OS/2 (and possibly  rsxnt + gcc
+ * for Windows NT) has a special _wildcard() function, which is already called
+ * at the top of the main() function below.
  *
  * zlib info:		http://www.zlib.net/
  * PNG/MNG/JNG info:	http://www.libpng.org/pub/png/


### PR DESCRIPTION
This is an alternative to PR #44 "Import the `wildargs` library: automatic expansion of wildcard arguments".

This is both a less heavy-handed and a less complete solution than #44, which you might still want to consider if you prefer to keep the C source code a little cleaner and the build files a little dirtier.

To be completely honest, my other solution, based on my `wildargs.c` implementation, is not that much more complete than this one. I mean, it does cover a few more compiler+library combinations, but yet more compilers, including Windows compilers, are left out.

In any case, @svgeesus, now you have two competing solutions to one problem. Plus one extra problem: you need to make the call: which one of these are going to be :stuck_out_tongue: