### PR TITLE
Add continuous integration using GitHub Actions

### DIFF
--- a/.github/workflows/build-makefile.yml
+++ b/.github/workflows/build-makefile.yml
@@ -1,0 +1,72 @@
+name: build-makefile
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: '${{ github.workflow }}-${{ github.job }}-${{ github.head_ref || github.ref_name }}'
+  cancel-in-progress: true
+
+jobs:
+  load-matrix:
+    name: Load Build Matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set matrix outputs
+        id: set-matrix
+        run: |
+          echo "matrix=$(jq -c '.' matrix-makefile.json)" >> $GITHUB_OUTPUT
+
+  build-makefile:
+    name: ${{ matrix.name }}-makefile
+    runs-on: ${{ matrix.runner }}
+    needs: load-matrix
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.load-matrix.outputs.matrix) }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    # Ubuntu dependencies
+    - name: Install dependencies (Ubuntu)
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y build-essential zlib1g-dev
+
+    # Makefile builds
+    - name: Build with Makefile (Ubuntu)
+      run: |
+        make
+
+    - name: Test Makefile build (Ubuntu)
+      run: |
+        ./pngcheck -h
+
+    # - name: Prepare artifacts (Ubuntu)
+    #   run: |
+    #     mkdir -p artifacts
+    #     cp pngcheck artifacts/pngcheck-${{ matrix.name }}-makefile
+    #     cd artifacts
+    #     if command -v sha256sum >/dev/null 2>&1; then
+    #       sha256sum * > checksums.txt
+    #     elif command -v shasum >/dev/null 2>&1; then
+    #       shasum -a 256 * > checksums.txt
+    #     fi
+
+    # - name: Upload artifacts
+    #   uses: actions/upload-artifact@v4
+    #   with:
+    #     name: pngcheck-${{ matrix.name }}-makefile
+    #     path: artifacts/
+    #     retention-days: 30

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,159 @@
+name: build-cmake
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: '${{ github.workflow }}-${{ github.job }}-${{ github.head_ref || github.ref_name }}'
+  cancel-in-progress: true
+
+jobs:
+  load-matrix:
+    name: Load Build Matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set matrix outputs
+        id: set-matrix
+        run: |
+          echo "matrix=$(jq -c '.' matrix.json)" >> $GITHUB_OUTPUT
+
+  build-cmake:
+    name: ${{ matrix.name }}-cmake
+    runs-on: ${{ matrix.runner }}
+    needs: load-matrix
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.load-matrix.outputs.matrix) }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    # MSYS2 setup
+    - name: Setup MSYS2
+      if: matrix.os == 'windows-msys2'
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: ${{ matrix.msys }}
+        path-type: minimal
+        update: true
+        install: >-
+          git
+          make
+        pacboy: >-
+          toolchain:p
+          zlib:p
+          cmake:p
+
+    # Ubuntu dependencies
+    - name: Install dependencies (Ubuntu)
+      if: matrix.os == 'ubuntu'
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y cmake build-essential zlib1g-dev
+
+    # macOS dependencies
+    - name: Install dependencies (macOS)
+      if: matrix.os == 'macos'
+      run: |
+        brew list zlib || brew install zlib
+
+    # Windows dependencies
+    - name: Setup MSVC (Windows)
+      if: matrix.os == 'windows'
+      uses: microsoft/setup-msbuild@v2
+
+    - name: Install vcpkg dependencies (Windows)
+      if: matrix.os == 'windows'
+      run: |
+        $arch = if ("${{ matrix.runner }}" -eq "windows-11-arm") { "arm64" } else { "x64" }
+        vcpkg install zlib:$arch-windows
+
+    # CMake builds
+    - name: Build with CMake (Ubuntu/macOS)
+      if: matrix.os == 'ubuntu' || matrix.os == 'macos'
+      run: |
+        cmake -B build-cmake \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DPNGCHECK_USE_SYSTEM_ZLIB=ON
+        cmake --build build-cmake --config Release
+
+    - name: Build with CMake (Windows MSVC)
+      if: matrix.os == 'windows'
+      run: |
+        $arch = if ("${{ matrix.runner }}" -eq "windows-11-arm") { "ARM64" } else { "x64" }
+        cmake -B build-cmake -A $arch -DCMAKE_BUILD_TYPE=Release -DPNGCHECK_USE_SYSTEM_ZLIB=ON -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake
+        cmake --build build-cmake --config Release
+
+    - name: Build with CMake (Windows MSYS2)
+      if: matrix.os == 'windows-msys2'
+      shell: msys2 {0}
+      run: |
+        cmake -B build-cmake \
+          -G "MSYS Makefiles" \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DPNGCHECK_USE_SYSTEM_ZLIB=ON
+        cmake --build build-cmake --config Release
+
+    # Testing CMake builds
+    - name: Test CMake build (MSYS2)
+      if: matrix.os == 'windows-msys2'
+      shell: msys2 {0}
+      run: |
+        build-cmake/pngcheck.exe -h
+
+    - name: Test CMake build (Windows MSVC)
+      if: matrix.os == 'windows'
+      run: |
+        build-cmake/Release/pngcheck.exe -h
+
+    - name: Test CMake build (Unix/macOS)
+      if: matrix.os == 'ubuntu' || matrix.os == 'macos'
+      run: |
+        ./build-cmake/pngcheck -h
+
+    # Artifacts
+    - name: Prepare artifacts (MSYS2)
+      if: matrix.os == 'windows-msys2'
+      shell: msys2 {0}
+      run: |
+        mkdir -p artifacts
+        cp build-cmake/pngcheck.exe artifacts/pngcheck-${{ matrix.name }}-cmake.exe
+        cd artifacts
+        sha256sum * > checksums.txt
+
+    - name: Prepare artifacts (Windows MSVC)
+      if: matrix.os == 'windows'
+      run: |
+        mkdir -p artifacts
+        cp build-cmake/Release/pngcheck.exe artifacts/pngcheck-${{ matrix.name }}-cmake.exe
+        cd artifacts
+        Get-FileHash -Algorithm SHA256 *.exe | ForEach-Object { "$($_.Hash.ToLower())  $($_.Path | Split-Path -Leaf)" } > checksums.txt
+
+    - name: Prepare artifacts (Unix/macOS)
+      if: matrix.os == 'ubuntu' || matrix.os == 'macos'
+      run: |
+        mkdir -p artifacts
+        cp build-cmake/pngcheck artifacts/pngcheck-${{ matrix.name }}-cmake
+        cd artifacts
+        if command -v sha256sum >/dev/null 2>&1; then
+          sha256sum * > checksums.txt
+        elif command -v shasum >/dev/null 2>&1; then
+          shasum -a 256 * > checksums.txt
+        fi
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: pngcheck-${{ matrix.name }}-cmake
+        path: artifacts/
+        retention-days: 30

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,107 @@
+name: release
+
+on:
+  push:
+    tags:
+    - 'v*'
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build Release Artifacts
+    runs-on: ${{ matrix.runner }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Ubuntu 22.04 builds only, compatibile with 22+ later versions
+          - runner: ubuntu-22.04
+            os: ubuntu
+            arch: x64
+          - runner: ubuntu-22.04-arm
+            os: ubuntu
+            arch: arm64
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y zlib1g-dev cmake build-essential
+
+    - name: Configure CMake
+      run: |
+        cmake -B build \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DPNGCHECK_USE_SYSTEM_ZLIB=ON
+
+    - name: Build
+      run: cmake --build build --config Release
+
+    - name: Prepare release artifacts
+      run: |
+        mkdir -p release-artifacts
+        cp build/pngcheck release-artifacts/pngcheck-${{ matrix.runner }}-${{ matrix.arch }}
+
+        # Generate checksums
+        cd release-artifacts
+        sha256sum * > checksums-${{ matrix.runner }}-${{ matrix.arch }}.txt
+
+    - name: Upload release artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: pngcheck-${{ matrix.runner }}-${{ matrix.arch }}
+        path: release-artifacts/
+        retention-days: 90
+
+  release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/')
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Download all artifacts
+      uses: actions/download-artifact@v4
+      with:
+        path: all-artifacts
+
+    - name: Prepare release assets
+      run: |
+        mkdir -p release-assets
+
+        # Flatten artifact structure and rename files
+        find all-artifacts -type f -name "pngcheck*" -exec cp {} release-assets/ \;
+        find all-artifacts -type f -name "checksums*" -exec cp {} release-assets/ \;
+
+        # Create a combined checksums file
+        cd release-assets
+        cat checksums-*.txt > combined-checksums.txt
+
+        # List all files for verification
+        ls -la
+
+    - name: Create Release
+      uses: softprops/action-gh-release@v1
+      with:
+        name: Release ${{ github.ref_name }}
+        body: |
+          ## pngcheck ${{ github.ref_name }}
+
+          Compiled binaries for Ubuntu 22.04:
+
+          ### Ubuntu 22.04
+          - `pngcheck-ubuntu-22.04-x64` - Ubuntu 22.04 (x64)
+          - `pngcheck-ubuntu-22.04-arm-arm64` - Ubuntu 22.04 (ARM64)
+
+          All binaries are built with CMake and system zlib, and include SHA256 checksums for verification.
+        files: release-assets/*
+        draft: false
+        prerelease: false
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,7 @@
  *   GRR  -  Greg Roelofs
  *   JB   -  John Bowler
  *   TGL  -  Tom Lane
+ *   RT   -  Ronald Tse (Ribose)
  *
  * 19950223 AL:  fixed wrong magic numbers
  *               ["version 1.1"]
@@ -290,3 +291,7 @@
  * 20250604 CT:  Required the zlib library as a non-optional dependency, and
                  removed the need to define the USE_ZLIB macro externally
  * 20250605 CT:  Added third_party/wildargs to auto-expand wildcard arguments
+ * 20250707 RT:  Prevent hard fails on chunks of unknown type in compliance with
+                 PNG spec. By Maxim Samsonov (Ribose), metanorma/pngcheck-metanorma#1.
+ * 20250708 RT:  Added CI workflows and Windows Makefiles (MSVC and MinGW) for GitHub
+                 Actions on Linux, macOS, and Windows.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -10,6 +10,8 @@
 
 ### Using CMake (recommended)
 
+#### Unix/Linux/etc.
+
 1. Create a build directory:
 
    ```sh
@@ -38,6 +40,51 @@
    # Depending your system setup, you might need to use 'sudo'
    cmake --install .
    ```
+
+#### Windows (MSVC with vcpkg)
+
+1. Install zlib via vcpkg:
+
+   ```cmd
+   vcpkg install zlib:x64-windows
+   # For ARM64: vcpkg install zlib:arm64-windows
+   ```
+
+2. Configure and build:
+
+   ```cmd
+   cmake -B build -A x64 -DCMAKE_BUILD_TYPE=Release -DPNGCHECK_USE_SYSTEM_ZLIB=ON -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake
+   # For ARM64: cmake -B build -A ARM64 -DCMAKE_BUILD_TYPE=Release -DPNGCHECK_USE_SYSTEM_ZLIB=ON -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake --build build --config Release
+   ```
+
+#### Windows (MSYS2/MinGW)
+
+1. Install dependencies in MSYS2:
+
+   ```sh
+   pacman -S mingw-w64-x86_64-toolchain mingw-w64-x86_64-zlib mingw-w64-x86_64-cmake
+   # For 32-bit: mingw-w64-i686-toolchain mingw-w64-i686-zlib mingw-w64-i686-cmake
+   ```
+
+2. Configure and build:
+
+   ```sh
+   cmake -B build -G "MSYS Makefiles" -DCMAKE_BUILD_TYPE=Release -DPNGCHECK_USE_SYSTEM_ZLIB=ON
+   cmake --build build --config Release
+   ```
+
+#### macOS (with Homebrew zlib)
+
+If using Homebrew-installed zlib instead of system zlib:
+
+1. Install zlib via Homebrew:
+
+   ```sh
+   brew install zlib
+   ```
+
+2. Configure and build (same as generic instructions above)
 
 ### Using Make (the traditional method)
 

--- a/matrix-makefile.json
+++ b/matrix-makefile.json
@@ -1,0 +1,12 @@
+[
+  {
+    "runner": "ubuntu-24.04",
+    "os": "ubuntu",
+    "name": "ubuntu-24.04"
+  },
+  {
+    "runner": "ubuntu-24.04-arm",
+    "os": "ubuntu",
+    "name": "ubuntu-24.04-arm"
+  }
+]

--- a/matrix.json
+++ b/matrix.json
@@ -1,18 +1,8 @@
 [
   {
-    "runner": "ubuntu-22.04",
-    "os": "ubuntu",
-    "name": "ubuntu-22.04"
-  },
-  {
     "runner": "ubuntu-24.04",
     "os": "ubuntu",
     "name": "ubuntu-24.04"
-  },
-  {
-    "runner": "ubuntu-22.04-arm",
-    "os": "ubuntu",
-    "name": "ubuntu-22.04-arm"
   },
   {
     "runner": "ubuntu-24.04-arm",
@@ -23,11 +13,6 @@
     "runner": "macos-13",
     "os": "macos",
     "name": "macos-13"
-  },
-  {
-    "runner": "macos-14",
-    "os": "macos",
-    "name": "macos-14"
   },
   {
     "runner": "macos-15",

--- a/matrix.json
+++ b/matrix.json
@@ -1,0 +1,59 @@
+[
+  {
+    "runner": "ubuntu-22.04",
+    "os": "ubuntu",
+    "name": "ubuntu-22.04"
+  },
+  {
+    "runner": "ubuntu-24.04",
+    "os": "ubuntu",
+    "name": "ubuntu-24.04"
+  },
+  {
+    "runner": "ubuntu-22.04-arm",
+    "os": "ubuntu",
+    "name": "ubuntu-22.04-arm"
+  },
+  {
+    "runner": "ubuntu-24.04-arm",
+    "os": "ubuntu",
+    "name": "ubuntu-24.04-arm"
+  },
+  {
+    "runner": "macos-13",
+    "os": "macos",
+    "name": "macos-13"
+  },
+  {
+    "runner": "macos-14",
+    "os": "macos",
+    "name": "macos-14"
+  },
+  {
+    "runner": "macos-15",
+    "os": "macos",
+    "name": "macos-15"
+  },
+  {
+    "runner": "windows-2022",
+    "os": "windows",
+    "name": "windows-2022"
+  },
+  {
+    "runner": "windows-11-arm",
+    "os": "windows",
+    "name": "windows-11-arm"
+  },
+  {
+    "runner": "windows-latest",
+    "os": "windows-msys2",
+    "msys": "mingw32",
+    "name": "mingw32"
+  },
+  {
+    "runner": "windows-latest",
+    "os": "windows-msys2",
+    "msys": "mingw64",
+    "name": "mingw64"
+  }
+]


### PR DESCRIPTION
Fixes #50.

(This PR was split from #51 , for your review @jbowler )

The current repository did not implement continuous integration and it is hard to ensure that the latest code and build methods work across the multitude of supported platforms.

We have added comprehensive workflows using GitHub Actions that test all supported build methods across multiple platforms, including:

* Ubuntu: 22.04, 24.04 (both x64 and arm64)
* macOS: 13 (Intel), 14 (arm64), 15 (arm64)
* Windows: 2022 (x64), 11 ARM (arm64), MinGW32, MinGW64

In accordance to INSTALL.md which describes CMake and Makefiles as both accepted/supported methods to build, two workflows are created:

* `build.yml` tests the CMake approach on all supported platforms (this PR)
* `build-makefile.yml` tests the Makefile approach on all supported platforms (this is now in #55)

Both workflows share a build matrix configuration which is encoded at `matrix.json`.

Specifically:

* The Windows Makefiles made a return (containing edits from @groelofs and @jbowler) to support the Makefile builds

* CMake builds use the following setup:
   - Ubuntu/macOS: System zlib integration
   - Windows MSVC: `vcpkg` integration with arm64 support
   - Windows MSYS2: MinGW32/64 with native toolchain

* Makefile builds use the following setup: (this is now in #55)
   - Ubuntu/macOS: normal `make`
   - Windows MSVC: `nmake` with `Makefile.w32`
   - Windows MinGW: `make` with `Makefile.mingw` (32/64-bit)

* An additional workflow for packaging a release at GitHub Releases is added which is triggered by pushing of a version tag (i.e. `v*`).

Caveat:

* While a custom/manual zlib is also supported, I did not add that to the CI since it would result in too many jobs, a give or take given that most users would be using the system zlib (across platforms).

## Credits

* This is a contribution from the Metanorma project (@metanorma) at Ribose (@riboseinc)
* Originally implemented at: https://github.com/metanorma/pngcheck-metanorma/pull/2, https://github.com/metanorma/pngcheck-metanorma/pull/6
