### PR TITLE
Add Makefile build workflow with Windows Makefiles

### DIFF
--- a/.github/workflows/build-makefile.yml
+++ b/.github/workflows/build-makefile.yml
@@ -1,0 +1,181 @@
+name: build-makefile
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: '${{ github.workflow }}-${{ github.job }}-${{ github.head_ref || github.ref_name }}'
+  cancel-in-progress: true
+
+jobs:
+  load-matrix:
+    name: Load Build Matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set matrix outputs
+        id: set-matrix
+        run: |
+          echo "matrix=$(jq -c '.' matrix.json)" >> $GITHUB_OUTPUT
+
+  build-makefile:
+    name: ${{ matrix.name }}-makefile
+    runs-on: ${{ matrix.runner }}
+    needs: load-matrix
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.load-matrix.outputs.matrix) }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    # MSYS2 setup
+    - name: Setup MSYS2
+      if: matrix.os == 'windows-msys2'
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: ${{ matrix.msys }}
+        path-type: minimal
+        update: true
+        install: >-
+          git
+          make
+        pacboy: >-
+          toolchain:p
+          zlib:p
+
+    # Ubuntu dependencies
+    - name: Install dependencies (Ubuntu)
+      if: matrix.os == 'ubuntu'
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y build-essential zlib1g-dev
+
+    # macOS dependencies
+    - name: Install dependencies (macOS)
+      if: matrix.os == 'macos'
+      run: |
+        # Check if zlib is available (either system or Homebrew)
+        if ! pkg-config --exists zlib 2>/dev/null && ! brew list zlib >/dev/null 2>&1; then
+          echo "Installing zlib via Homebrew..."
+          brew install zlib
+        else
+          echo "zlib is already available (system or Homebrew)"
+        fi
+
+    # Windows MSVC dependencies
+    - name: Setup MSVC (Windows)
+      if: matrix.os == 'windows'
+      uses: microsoft/setup-msbuild@v2
+
+    - name: Install vcpkg dependencies (Windows)
+      if: matrix.os == 'windows'
+      run: |
+        $arch = if ("${{ matrix.runner }}" -eq "windows-11-arm") { "arm64" } else { "x64" }
+        vcpkg install zlib:$arch-windows
+
+    # Makefile builds
+    - name: Build with Makefile (Ubuntu/macOS)
+      if: matrix.os == 'ubuntu' || matrix.os == 'macos'
+      run: |
+        make
+
+    - name: Build with Makefile (Windows MSVC)
+      if: matrix.os == 'windows'
+      run: |
+        # Set up MSVC environment
+        $vsPath = "${env:ProgramFiles}\Microsoft Visual Studio\2022\Enterprise"
+        if (-not (Test-Path $vsPath)) {
+          $vsPath = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2022\BuildTools"
+        }
+
+        $vcvarsPath = "$vsPath\VC\Auxiliary\Build\vcvars64.bat"
+        $triplet = "x64-windows"
+        if ("${{ matrix.runner }}" -eq "windows-11-arm") {
+          $vcvarsPath = "$vsPath\VC\Auxiliary\Build\vcvarsamd64_arm64.bat"
+          $triplet = "arm64-windows"
+        }
+
+        # Build with nmake - explicitly set environment variables in cmd
+        cmd /c "`"$vcvarsPath`" && set `"VCPKG_ROOT=C:\vcpkg`" && set `"VCPKG_TARGET_TRIPLET=$triplet`" && nmake -f Makefile.w32"
+
+    - name: Build with Makefile (Windows MSYS2)
+      if: matrix.os == 'windows-msys2'
+      shell: msys2 {0}
+      run: |
+        if [[ "${{ matrix.msys }}" == "mingw32" ]]; then
+          make -f Makefile.mingw ARCH=32
+        else
+          make -f Makefile.mingw ARCH=64
+        fi
+
+    # Testing Makefile builds
+    - name: Test Makefile build (MSYS2)
+      if: matrix.os == 'windows-msys2'
+      shell: msys2 {0}
+      run: |
+        if [[ "${{ matrix.msys }}" == "mingw32" ]]; then
+          ./pngcheck.win32.exe -h
+        else
+          ./pngcheck.win64.exe -h
+        fi
+
+    - name: Test Makefile build (Windows MSVC)
+      if: matrix.os == 'windows'
+      run: |
+        .\pngcheck.exe -h
+
+    - name: Test Makefile build (Unix/macOS)
+      if: matrix.os == 'ubuntu' || matrix.os == 'macos'
+      run: |
+        ./pngcheck -h
+
+    # Artifacts
+    - name: Prepare artifacts (MSYS2)
+      if: matrix.os == 'windows-msys2'
+      shell: msys2 {0}
+      run: |
+        mkdir -p artifacts
+        if [[ "${{ matrix.msys }}" == "mingw32" ]]; then
+          cp pngcheck.win32.exe artifacts/pngcheck-${{ matrix.name }}-makefile.exe
+        else
+          cp pngcheck.win64.exe artifacts/pngcheck-${{ matrix.name }}-makefile.exe
+        fi
+        cd artifacts
+        sha256sum * > checksums.txt
+
+    - name: Prepare artifacts (Windows MSVC)
+      if: matrix.os == 'windows'
+      run: |
+        mkdir -p artifacts
+        cp pngcheck.exe artifacts/pngcheck-${{ matrix.name }}-makefile.exe
+        cd artifacts
+        Get-FileHash -Algorithm SHA256 *.exe | ForEach-Object { "$($_.Hash.ToLower())  $($_.Path | Split-Path -Leaf)" } > checksums.txt
+
+    - name: Prepare artifacts (Unix/macOS)
+      if: matrix.os == 'ubuntu' || matrix.os == 'macos'
+      run: |
+        mkdir -p artifacts
+        cp pngcheck artifacts/pngcheck-${{ matrix.name }}-makefile
+        cd artifacts
+        if command -v sha256sum >/dev/null 2>&1; then
+          sha256sum * > checksums.txt
+        elif command -v shasum >/dev/null 2>&1; then
+          shasum -a 256 * > checksums.txt
+        fi
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: pngcheck-${{ matrix.name }}-makefile
+        path: artifacts/
+        retention-days: 30

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,159 @@
+name: build-cmake
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: '${{ github.workflow }}-${{ github.job }}-${{ github.head_ref || github.ref_name }}'
+  cancel-in-progress: true
+
+jobs:
+  load-matrix:
+    name: Load Build Matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set matrix outputs
+        id: set-matrix
+        run: |
+          echo "matrix=$(jq -c '.' matrix.json)" >> $GITHUB_OUTPUT
+
+  build-cmake:
+    name: ${{ matrix.name }}-cmake
+    runs-on: ${{ matrix.runner }}
+    needs: load-matrix
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.load-matrix.outputs.matrix) }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    # MSYS2 setup
+    - name: Setup MSYS2
+      if: matrix.os == 'windows-msys2'
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: ${{ matrix.msys }}
+        path-type: minimal
+        update: true
+        install: >-
+          git
+          make
+        pacboy: >-
+          toolchain:p
+          zlib:p
+          cmake:p
+
+    # Ubuntu dependencies
+    - name: Install dependencies (Ubuntu)
+      if: matrix.os == 'ubuntu'
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y cmake build-essential zlib1g-dev
+
+    # macOS dependencies
+    - name: Install dependencies (macOS)
+      if: matrix.os == 'macos'
+      run: |
+        brew list zlib || brew install zlib
+
+    # Windows dependencies
+    - name: Setup MSVC (Windows)
+      if: matrix.os == 'windows'
+      uses: microsoft/setup-msbuild@v2
+
+    - name: Install vcpkg dependencies (Windows)
+      if: matrix.os == 'windows'
+      run: |
+        $arch = if ("${{ matrix.runner }}" -eq "windows-11-arm") { "arm64" } else { "x64" }
+        vcpkg install zlib:$arch-windows
+
+    # CMake builds
+    - name: Build with CMake (Ubuntu/macOS)
+      if: matrix.os == 'ubuntu' || matrix.os == 'macos'
+      run: |
+        cmake -B build-cmake \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DPNGCHECK_USE_SYSTEM_ZLIB=ON
+        cmake --build build-cmake --config Release
+
+    - name: Build with CMake (Windows MSVC)
+      if: matrix.os == 'windows'
+      run: |
+        $arch = if ("${{ matrix.runner }}" -eq "windows-11-arm") { "ARM64" } else { "x64" }
+        cmake -B build-cmake -A $arch -DCMAKE_BUILD_TYPE=Release -DPNGCHECK_USE_SYSTEM_ZLIB=ON -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake
+        cmake --build build-cmake --config Release
+
+    - name: Build with CMake (Windows MSYS2)
+      if: matrix.os == 'windows-msys2'
+      shell: msys2 {0}
+      run: |
+        cmake -B build-cmake \
+          -G "MSYS Makefiles" \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DPNGCHECK_USE_SYSTEM_ZLIB=ON
+        cmake --build build-cmake --config Release
+
+    # Testing CMake builds
+    - name: Test CMake build (MSYS2)
+      if: matrix.os == 'windows-msys2'
+      shell: msys2 {0}
+      run: |
+        build-cmake/pngcheck.exe -h
+
+    - name: Test CMake build (Windows MSVC)
+      if: matrix.os == 'windows'
+      run: |
+        build-cmake/Release/pngcheck.exe -h
+
+    - name: Test CMake build (Unix/macOS)
+      if: matrix.os == 'ubuntu' || matrix.os == 'macos'
+      run: |
+        ./build-cmake/pngcheck -h
+
+    # Artifacts
+    - name: Prepare artifacts (MSYS2)
+      if: matrix.os == 'windows-msys2'
+      shell: msys2 {0}
+      run: |
+        mkdir -p artifacts
+        cp build-cmake/pngcheck.exe artifacts/pngcheck-${{ matrix.name }}-cmake.exe
+        cd artifacts
+        sha256sum * > checksums.txt
+
+    - name: Prepare artifacts (Windows MSVC)
+      if: matrix.os == 'windows'
+      run: |
+        mkdir -p artifacts
+        cp build-cmake/Release/pngcheck.exe artifacts/pngcheck-${{ matrix.name }}-cmake.exe
+        cd artifacts
+        Get-FileHash -Algorithm SHA256 *.exe | ForEach-Object { "$($_.Hash.ToLower())  $($_.Path | Split-Path -Leaf)" } > checksums.txt
+
+    - name: Prepare artifacts (Unix/macOS)
+      if: matrix.os == 'ubuntu' || matrix.os == 'macos'
+      run: |
+        mkdir -p artifacts
+        cp build-cmake/pngcheck artifacts/pngcheck-${{ matrix.name }}-cmake
+        cd artifacts
+        if command -v sha256sum >/dev/null 2>&1; then
+          sha256sum * > checksums.txt
+        elif command -v shasum >/dev/null 2>&1; then
+          shasum -a 256 * > checksums.txt
+        fi
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: pngcheck-${{ matrix.name }}-cmake
+        path: artifacts/
+        retention-days: 30

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,107 @@
+name: release
+
+on:
+  push:
+    tags:
+    - 'v*'
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build Release Artifacts
+    runs-on: ${{ matrix.runner }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Ubuntu 22.04 builds only, compatibile with 22+ later versions
+          - runner: ubuntu-22.04
+            os: ubuntu
+            arch: x64
+          - runner: ubuntu-22.04-arm
+            os: ubuntu
+            arch: arm64
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y zlib1g-dev cmake build-essential
+
+    - name: Configure CMake
+      run: |
+        cmake -B build \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DPNGCHECK_USE_SYSTEM_ZLIB=ON
+
+    - name: Build
+      run: cmake --build build --config Release
+
+    - name: Prepare release artifacts
+      run: |
+        mkdir -p release-artifacts
+        cp build/pngcheck release-artifacts/pngcheck-${{ matrix.runner }}-${{ matrix.arch }}
+
+        # Generate checksums
+        cd release-artifacts
+        sha256sum * > checksums-${{ matrix.runner }}-${{ matrix.arch }}.txt
+
+    - name: Upload release artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: pngcheck-${{ matrix.runner }}-${{ matrix.arch }}
+        path: release-artifacts/
+        retention-days: 90
+
+  release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/')
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Download all artifacts
+      uses: actions/download-artifact@v4
+      with:
+        path: all-artifacts
+
+    - name: Prepare release assets
+      run: |
+        mkdir -p release-assets
+
+        # Flatten artifact structure and rename files
+        find all-artifacts -type f -name "pngcheck*" -exec cp {} release-assets/ \;
+        find all-artifacts -type f -name "checksums*" -exec cp {} release-assets/ \;
+
+        # Create a combined checksums file
+        cd release-assets
+        cat checksums-*.txt > combined-checksums.txt
+
+        # List all files for verification
+        ls -la
+
+    - name: Create Release
+      uses: softprops/action-gh-release@v1
+      with:
+        name: Release ${{ github.ref_name }}
+        body: |
+          ## pngcheck ${{ github.ref_name }}
+
+          Compiled binaries for Ubuntu 22.04:
+
+          ### Ubuntu 22.04
+          - `pngcheck-ubuntu-22.04-x64` - Ubuntu 22.04 (x64)
+          - `pngcheck-ubuntu-22.04-arm-arm64` - Ubuntu 22.04 (ARM64)
+
+          All binaries are built with CMake and system zlib, and include SHA256 checksums for verification.
+        files: release-assets/*
+        draft: false
+        prerelease: false
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,7 @@
  *   GRR  -  Greg Roelofs
  *   JB   -  John Bowler
  *   TGL  -  Tom Lane
+ *   RT   -  Ronald Tse (Ribose)
  *
  * 19950223 AL:  fixed wrong magic numbers
  *               ["version 1.1"]
@@ -290,3 +291,7 @@
  * 20250604 CT:  Required the zlib library as a non-optional dependency, and
                  removed the need to define the USE_ZLIB macro externally
  * 20250605 CT:  Added third_party/wildargs to auto-expand wildcard arguments
+ * 20250707 RT:  Prevent hard fails on chunks of unknown type in compliance with
+                 PNG spec. By Maxim Samsonov (Ribose), metanorma/pngcheck-metanorma#1.
+ * 20250708 RT:  Added CI workflows and Windows Makefiles (MSVC and MinGW) for GitHub
+                 Actions on Linux, macOS, and Windows.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -10,6 +10,8 @@
 
 ### Using CMake (recommended)
 
+#### Unix/Linux/etc.
+
 1. Create a build directory:
 
    ```sh
@@ -38,6 +40,51 @@
    # Depending your system setup, you might need to use 'sudo'
    cmake --install .
    ```
+
+#### Windows (MSVC with vcpkg)
+
+1. Install zlib via vcpkg:
+
+   ```cmd
+   vcpkg install zlib:x64-windows
+   # For ARM64: vcpkg install zlib:arm64-windows
+   ```
+
+2. Configure and build:
+
+   ```cmd
+   cmake -B build -A x64 -DCMAKE_BUILD_TYPE=Release -DPNGCHECK_USE_SYSTEM_ZLIB=ON -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake
+   # For ARM64: cmake -B build -A ARM64 -DCMAKE_BUILD_TYPE=Release -DPNGCHECK_USE_SYSTEM_ZLIB=ON -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake
+   cmake --build build --config Release
+   ```
+
+#### Windows (MSYS2/MinGW)
+
+1. Install dependencies in MSYS2:
+
+   ```sh
+   pacman -S mingw-w64-x86_64-toolchain mingw-w64-x86_64-zlib mingw-w64-x86_64-cmake
+   # For 32-bit: mingw-w64-i686-toolchain mingw-w64-i686-zlib mingw-w64-i686-cmake
+   ```
+
+2. Configure and build:
+
+   ```sh
+   cmake -B build -G "MSYS Makefiles" -DCMAKE_BUILD_TYPE=Release -DPNGCHECK_USE_SYSTEM_ZLIB=ON
+   cmake --build build --config Release
+   ```
+
+#### macOS (with Homebrew zlib)
+
+If using Homebrew-installed zlib instead of system zlib:
+
+1. Install zlib via Homebrew:
+
+   ```sh
+   brew install zlib
+   ```
+
+2. Configure and build (same as generic instructions above)
 
 ### Using Make (the traditional method)
 

--- a/Makefile.mingw
+++ b/Makefile.mingw
@@ -1,0 +1,86 @@
+# Makefile for pngcheck using MinGW (native or cross-compilation)
+# Greg Roelofs et al.
+# Last modified: 8 July 2025
+#
+# This makefile assumes zlib has either been built in a subdirectory at the
+# same level as the current subdirectory (as indicated by the ZLIB_PATH macro
+# below), or installed system-wide. Edit the ZLIB_* macros as appropriate.
+#
+# Invoke this makefile via:
+#	make -f Makefile.mingw                   # defaults to 64-bit
+#	make -f Makefile.mingw ARCH=32           # for 32-bit
+#	make -f Makefile.mingw ARCH=64           # for 64-bit (explicit)
+
+
+# macros --------------------------------------------------------------------
+
+# Architecture selection (default to 64-bit)
+ARCH ?= 64
+
+# Set architecture-specific variables
+ifeq ($(ARCH),32)
+    EXEEXT = .win32.exe
+    ARCH_FLAGS = -m32
+else
+    EXEEXT = .win64.exe
+    ARCH_FLAGS = -m64
+endif
+
+ZLIB_PATH = ../zlib
+ZLIB_INCPATH = $(ZLIB_PATH)
+ZLIB_LIBPATH = $(ZLIB_PATH)
+ZLIB_LIB = -l:libz.a
+
+CC = gcc
+LD = $(CC)
+RM_F = rm -f
+
+STDC = -std=c99
+WARN = -Wall -Wextra -Wundef
+WARNMORE = -Wcast-align -Wconversion -Wpointer-arith -Wwrite-strings \
+           -Wmissing-declarations -Wmissing-prototypes -Wstrict-prototypes \
+           -Wno-implicit-fallthrough
+LOCAL_CPPFLAGS = -DUSE_ZLIB
+LOCAL_CFLAGS = $(STDC) $(WARN) $(ARCH_FLAGS) # $(WARNMORE)
+LOCAL_LDFLAGS = $(ARCH_FLAGS)
+
+CPPFLAGS = -I$(ZLIB_INCPATH)
+CFLAGS = -O2 # -g
+LDFLAGS = -L$(ZLIB_LIBPATH) # -g
+LIBS = $(ZLIB_LIB)
+
+ALL_CPPFLAGS = $(LOCAL_CPPFLAGS) $(CPPFLAGS)
+ALL_CFLAGS = $(LOCAL_CFLAGS) $(CFLAGS)
+ALL_LDFLAGS = $(LOCAL_LDFLAGS) $(LDFLAGS)
+
+EXES = pngcheck$(EXEEXT)
+OBJS = pngcheck.o
+
+
+# implicit make rules -------------------------------------------------------
+
+.c.o:
+	$(CC) -c $(ALL_CPPFLAGS) $(ALL_CFLAGS) -o $@ $*.c
+
+
+# dependencies --------------------------------------------------------------
+
+all: $(EXES)
+
+pngcheck$(EXEEXT): pngcheck.o
+	$(LD) $(ALL_LDFLAGS) -o $@ pngcheck.o $(LIBS)
+
+
+# maintenance ---------------------------------------------------------------
+
+clean:
+	$(RM_F) $(EXES) $(OBJS)
+
+# convenience targets
+win32:
+	$(MAKE) -f Makefile.mingw ARCH=32
+
+win64:
+	$(MAKE) -f Makefile.mingw ARCH=64
+
+.PHONY: all clean win32 win64

--- a/Makefile.w32
+++ b/Makefile.w32
@@ -1,0 +1,90 @@
+# Makefile for pngcheck using MSVC/Visual Studio
+# Greg Roelofs et al.
+# Last modified: 8 July 2025
+#
+# This makefile assumes zlib has either been built in a subdirectory at the
+# same level as the current subdirectory (as indicated by the ZLIB_PATH macro
+# below), or installed system-wide. Edit the ZLIB_* macros as appropriate.
+#
+# Invoke this makefile from a DOS prompt window via:
+#	%devstudio%\vc\bin\vcvars32.bat
+#	nmake -nologo -f Makefile.w32
+#
+# where %devstudio% is the installation directory for MSVC / DevStudio.
+
+#!include <ntwin32.mak>
+
+
+# macros --------------------------------------------------------------------
+
+
+# Use vcpkg-installed zlib if VCPKG_ROOT is set, otherwise use local paths
+!IF "$(VCPKG_ROOT)" != ""
+# Use immediate expansion to avoid space issues
+VCPKG_BASE = $(VCPKG_ROOT)\installed\$(VCPKG_TARGET_TRIPLET)
+ZLIB_INCPATH = $(VCPKG_BASE)\include
+ZLIB_LIBPATH = $(VCPKG_BASE)\lib
+ZLIB_LIB = $(VCPKG_BASE)\lib\zlib.lib
+!MESSAGE Using vcpkg zlib from: $(VCPKG_BASE)
+!ELSE
+ZLIB_PATH = ../zlib
+ZLIB_INCPATH = $(ZLIB_PATH)
+ZLIB_LIBPATH = $(ZLIB_PATH)
+ZLIB_LIB = $(ZLIB_PATH)\zlibstat.lib
+!MESSAGE Using local zlib from: $(ZLIB_PATH)
+!ENDIF
+
+CC = cl
+LD = link
+RM_F = del
+
+STDC = # /std:c11 or /std:c17 (MSVC 2019+)
+WARN = /W3
+WARNMORE = /Wall
+LOCAL_CPPFLAGS = /DUSE_ZLIB
+LOCAL_CFLAGS = /nologo $(STDC) $(WARN) $(cvars) # $(WARNMORE)
+LOCAL_LDFLAGS = /nologo
+
+CPPFLAGS = $(LOCAL_CPPFLAGS) /I"$(ZLIB_INCPATH)"
+CFLAGS = /O2 # /Zi for debug
+LDFLAGS = # /DEBUG for debug
+LIBS = "$(ZLIB_LIB)"
+
+ALL_CPPFLAGS = $(CPPFLAGS)
+ALL_CFLAGS = $(LOCAL_CFLAGS) $(CFLAGS)
+ALL_LDFLAGS = $(LOCAL_LDFLAGS) $(LDFLAGS)
+
+EXEEXT = .exe
+OBJEXT = .obj
+EXES = pngcheck$(EXEEXT)
+OBJS = pngcheck$(OBJEXT)
+
+
+# implicit make rules -------------------------------------------------------
+
+.c$(OBJEXT):
+	$(CC) /c $(ALL_CPPFLAGS) $(ALL_CFLAGS) /Fo$@ $<
+
+
+# dependencies --------------------------------------------------------------
+
+all: $(EXES)
+
+# setargv.obj expands wildcards and is included as part of MSVC; may be called
+# "wildargs.obj" (or similar) for Borland or Watcom compilers
+pngcheck$(EXEEXT): $(OBJS)
+	$(LD) $(ALL_LDFLAGS) /out:$@ $(OBJS) setargv.obj $(LIBS)
+
+pngcheck$(OBJEXT): pngcheck.c
+
+
+# maintenance ---------------------------------------------------------------
+
+clean:
+#	ideally we could just do this:
+#	$(RM_F) $(EXES) $(OBJS)
+#	...but the Windows "DEL" command is none too bright, so:
+	$(RM_F) $(EXES)
+	$(RM_F) $(OBJS)
+
+.PHONY: all clean

--- a/matrix.json
+++ b/matrix.json
@@ -1,0 +1,59 @@
+[
+  {
+    "runner": "ubuntu-22.04",
+    "os": "ubuntu",
+    "name": "ubuntu-22.04"
+  },
+  {
+    "runner": "ubuntu-24.04",
+    "os": "ubuntu",
+    "name": "ubuntu-24.04"
+  },
+  {
+    "runner": "ubuntu-22.04-arm",
+    "os": "ubuntu",
+    "name": "ubuntu-22.04-arm"
+  },
+  {
+    "runner": "ubuntu-24.04-arm",
+    "os": "ubuntu",
+    "name": "ubuntu-24.04-arm"
+  },
+  {
+    "runner": "macos-13",
+    "os": "macos",
+    "name": "macos-13"
+  },
+  {
+    "runner": "macos-14",
+    "os": "macos",
+    "name": "macos-14"
+  },
+  {
+    "runner": "macos-15",
+    "os": "macos",
+    "name": "macos-15"
+  },
+  {
+    "runner": "windows-2022",
+    "os": "windows",
+    "name": "windows-2022"
+  },
+  {
+    "runner": "windows-11-arm",
+    "os": "windows",
+    "name": "windows-11-arm"
+  },
+  {
+    "runner": "windows-latest",
+    "os": "windows-msys2",
+    "msys": "mingw32",
+    "name": "mingw32"
+  },
+  {
+    "runner": "windows-latest",
+    "os": "windows-msys2",
+    "msys": "mingw64",
+    "name": "mingw64"
+  }
+]


### PR DESCRIPTION
Follow up to #52 as requested by @ctruta (FYI @jbowler ) at:

* https://github.com/pnggroup/pngcheck/pull/52#pullrequestreview-3028767429

NOTE: This is based on #52, so once #52 is merged this PR needs to be rebased.

This is a split from #52 where:

This PR adds the GitHub Actions build workflow that uses the traditional Makefile workflows for Windows, including:

* Windows: 2022 (x64), 11 ARM (arm64), MinGW32, MinGW64

In accordance to INSTALL.md which describes CMake and Makefiles as both accepted/supported methods to build, two workflows are created:

* `build-makefile.yml` tests the Makefile approach on all supported platforms

This workflow shares a build matrix configuration with the CMake workflow `build.yml` which is encoded at `matrix.json`.

Specifically:

* The Windows Makefiles made a return (containing edits from @groelofs and @jbowler) to support the Makefile builds

* Makefile builds use the following setup:
   - Ubuntu/macOS: normal `make`
   - Windows MSVC: `nmake` with `Makefile.w32`
   - Windows MinGW: `make` with `Makefile.mingw` (32/64-bit)

## Credits

* This is a contribution from the Metanorma project (@metanorma) at Ribose (@riboseinc)
* Originally implemented at: https://github.com/metanorma/pngcheck-metanorma/pull/2, https://github.com/metanorma/pngcheck-metanorma/pull/6
