### PR TITLE
chore: Apply a quick fix to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ a.out
 *.tds
 core
 core.[0-9]*
+!core/
 
 # Coverage testing artifacts
 *.gcda
@@ -91,13 +92,14 @@ xcuserdata/
 [._]*_history
 .history/
 [Bb]ackup*/
+CMakeLists.txt.user*
 CMakeUserPresets.json
 
 # Build, test and CI output directories
-/[Bb]uild*/
+[._]build*/
+/[Bb]uild/
 /[Oo]ut/
 *[Dd]ebug/
 [Dd]ebug*/
 *[Rr]elease/
 [Rr]elease*/
-[._]build*/


### PR DESCRIPTION
.gitignore was a little bit too ignore-happy (e.g. it ignored valid directory names like `build-aux/` because of the `[Bb]uild*` pattern, and it also ignored valid directory names like `core/`). On the other hand, it missed a CMake artifact produced by IDEs like QtCreator.

I fixed it in libpng as well, BTW.